### PR TITLE
PW-2603 remove customer id from shopperinfo payload

### DIFF
--- a/Components/Payload/Providers/ShopperInfoProvider.php
+++ b/Components/Payload/Providers/ShopperInfoProvider.php
@@ -31,7 +31,7 @@ class ShopperInfoProvider implements PaymentPayloadProvider
             'billingAddress' => [
                 'city' => $context->getOrder()->getBilling()->getCity(),
                 'country' => $context->getOrder()->getBilling()->getCountry()->getIso(),
-                'houseNumberOrName' => $context->getOrder()->getBilling()->getNumber(),
+                'houseNumberOrName' => '',
                 'postalCode' => $context->getOrder()->getBilling()->getZipCode(),
                 'street' => $context->getOrder()->getBilling()->getStreet(),
             ],


### PR DESCRIPTION
## Summary
The billing number is removed and the houseNumber field is now empty. Because Shopware saves the street and house number in the same field it's not possible to separate those values as indicated in the documentation:
https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v49/payments__reqParam_billingAddress

## Tested scenarios
Customer ID is not be included in the address fields

**Fixed issue**:  PW-2603
