### PR TITLE
Fix #22 PW-2743 Show error on 404

### DIFF
--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -65,10 +65,10 @@
                                 Shopware.Msg.createGrowlMessage('success', value.responseText)
                             },
                             failure: function (response) {
-                                var value = Ext.decode(response.responseText);
                                 if (response.status === 404) {
                                     Shopware.Msg.createGrowlMessage('Plugin Manager', 'Please activate plugin before testing.');
                                 } else {
+                                	var value = Ext.decode(response.responseText);
                                     Shopware.Msg.createGrowlMessage('failure', value.responseText)
                                 }
                             }

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -68,7 +68,7 @@
                                 if (response.status === 404) {
                                     Shopware.Msg.createGrowlMessage('Plugin Manager', 'Please activate plugin before testing.');
                                 } else {
-                                	var value = Ext.decode(response.responseText);
+                                    var value = Ext.decode(response.responseText);
                                     Shopware.Msg.createGrowlMessage('failure', value.responseText)
                                 }
                             }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Shows error message when 404 is returned from Test button. This means the plugin is not active.
-> Was actually already implemented this way, but badly.

## Tested scenarios
- Click test button before plugin is activated


**Fixed issue**:  #22 PW-2743
