### PR TITLE
Fixes #18 PW-2600 Catch exception during backend Test

### DIFF
--- a/Controllers/Backend/TestAdyenApi.php
+++ b/Controllers/Backend/TestAdyenApi.php
@@ -18,10 +18,14 @@ class Shopware_Controllers_Backend_TestAdyenApi extends Shopware_Controllers_Bac
             $responseText = 'Missing API configuration. Save the configuration form before testing';
         }
 
-        if (!empty($paymentMethodService->getPaymentMethods('BE', 'EUR', 20, 'nl_NL', false))) {
-            $this->response->setHttpResponseCode(Response::HTTP_OK);
-            $responseText = 'Adyen API connected';
-        }
+        try {
+			if (!empty($paymentMethodService->getPaymentMethods('BE', 'EUR', 20, 'nl_NL', false))) {
+				$this->response->setHttpResponseCode(Response::HTTP_OK);
+				$responseText = 'Adyen API connected';
+			}
+		} catch (\Exception $exception) {
+			$responseText = 'Adyen API failed, check error logs';
+		}
 
         $this->View()->assign('responseText', $responseText);
     }

--- a/Controllers/Backend/TestAdyenApi.php
+++ b/Controllers/Backend/TestAdyenApi.php
@@ -19,13 +19,13 @@ class Shopware_Controllers_Backend_TestAdyenApi extends Shopware_Controllers_Bac
         }
 
         try {
-			if (!empty($paymentMethodService->getPaymentMethods('BE', 'EUR', 20, 'nl_NL', false))) {
-				$this->response->setHttpResponseCode(Response::HTTP_OK);
-				$responseText = 'Adyen API connected';
-			}
-		} catch (\Exception $exception) {
-			$responseText = 'Adyen API failed, check error logs';
-		}
+            if (!empty($paymentMethodService->getPaymentMethods('BE', 'EUR', 20, 'nl_NL', false))) {
+                $this->response->setHttpResponseCode(Response::HTTP_OK);
+                $responseText = 'Adyen API connected';
+            }
+        } catch (\Exception $exception) {
+            $responseText = 'Adyen API failed, check error logs';
+        }
 
         $this->View()->assign('responseText', $responseText);
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Catch error in Test button controller and show error message instead of 'real' crash.

## Tested scenarios
Test button without valid URL prefix.


**Fixed issue**:  #18 PW-2600
