### PR TITLE
Fixes #15 Handle offer_closed notification

### DIFF
--- a/Components/NotificationProcessor/OfferClosed.php
+++ b/Components/NotificationProcessor/OfferClosed.php
@@ -11,72 +11,72 @@ use Shopware\Models\Order\Status;
 
 class OfferClosed implements NotificationProcessorInterface
 {
-	const EVENT_CODE = 'OFFER_CLOSED';
+    const EVENT_CODE = 'OFFER_CLOSED';
 
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
-	/**
-	 * @var ContainerAwareEventManager
-	 */
-	private $eventManager;
-	/**
-	 * @var PaymentStatusUpdate
-	 */
-	private $paymentStatusUpdate;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var ContainerAwareEventManager
+     */
+    private $eventManager;
+    /**
+     * @var PaymentStatusUpdate
+     */
+    private $paymentStatusUpdate;
 
-	public function __construct(
-		LoggerInterface $logger,
-		ContainerAwareEventManager $eventManager,
-		PaymentStatusUpdate $paymentStatusUpdate
-	) {
-		$this->logger = $logger;
-		$this->eventManager = $eventManager;
-		$this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
-	}
+    public function __construct(
+        LoggerInterface $logger,
+        ContainerAwareEventManager $eventManager,
+        PaymentStatusUpdate $paymentStatusUpdate
+    ) {
+        $this->logger = $logger;
+        $this->eventManager = $eventManager;
+        $this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
+    }
 
-	/**
-	 * Returns boolean on whether this processor can process the Notification object
-	 *
-	 * @param Notification $notification
-	 * @return boolean
-	 */
-	public function supports(Notification $notification): bool
-	{
-		return strtoupper($notification->getEventCode()) === self::EVENT_CODE;
-	}
+    /**
+     * Returns boolean on whether this processor can process the Notification object
+     *
+     * @param Notification $notification
+     * @return boolean
+     */
+    public function supports(Notification $notification): bool
+    {
+        return strtoupper($notification->getEventCode()) === self::EVENT_CODE;
+    }
 
-	/**
-	 * Actual processing of the notification
-	 *
-	 * @param Notification $notification
-	 * @throws \Doctrine\ORM\ORMException
-	 * @throws \Doctrine\ORM\OptimisticLockException
-	 * @throws \Doctrine\ORM\TransactionRequiredException
-	 * @throws \Enlight_Event_Exception
-	 */
-	public function process(Notification $notification)
-	{
-		$order = $notification->getOrder();
+    /**
+     * Actual processing of the notification
+     *
+     * @param Notification $notification
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     * @throws \Enlight_Event_Exception
+     */
+    public function process(Notification $notification)
+    {
+        $order = $notification->getOrder();
 
-		$this->eventManager->notify(
-			Event::NOTIFICATION_PROCESS_OFFER_CLOSED,
-			[
-				'order' => $order,
-				'notification' => $notification
-			]
-		);
+        $this->eventManager->notify(
+            Event::NOTIFICATION_PROCESS_OFFER_CLOSED,
+            [
+                'order' => $order,
+                'notification' => $notification
+            ]
+        );
 
-		if ($notification->isSuccess()) {
-			$this->paymentStatusUpdate->updateOrderStatus(
-				$order,
-				Status::ORDER_STATE_CANCELLED_REJECTED
-			);
-			$this->paymentStatusUpdate->updatePaymentStatus(
-				$order,
-				Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED
-			);
-		}
-	}
+        if ($notification->isSuccess()) {
+            $this->paymentStatusUpdate->updateOrderStatus(
+                $order,
+                Status::ORDER_STATE_CANCELLED_REJECTED
+            );
+            $this->paymentStatusUpdate->updatePaymentStatus(
+                $order,
+                Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED
+            );
+        }
+    }
 }

--- a/Components/NotificationProcessor/OfferClosed.php
+++ b/Components/NotificationProcessor/OfferClosed.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AdyenPayment\Components\NotificationProcessor;
+
+use AdyenPayment\Components\PaymentStatusUpdate;
+use AdyenPayment\Models\Event;
+use AdyenPayment\Models\Notification;
+use Psr\Log\LoggerInterface;
+use Shopware\Components\ContainerAwareEventManager;
+use Shopware\Models\Order\Status;
+
+class OfferClosed implements NotificationProcessorInterface
+{
+	const EVENT_CODE = 'OFFER_CLOSED';
+
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
+	/**
+	 * @var ContainerAwareEventManager
+	 */
+	private $eventManager;
+	/**
+	 * @var PaymentStatusUpdate
+	 */
+	private $paymentStatusUpdate;
+
+	public function __construct(
+		LoggerInterface $logger,
+		ContainerAwareEventManager $eventManager,
+		PaymentStatusUpdate $paymentStatusUpdate
+	) {
+		$this->logger = $logger;
+		$this->eventManager = $eventManager;
+		$this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
+	}
+
+	/**
+	 * Returns boolean on whether this processor can process the Notification object
+	 *
+	 * @param Notification $notification
+	 * @return boolean
+	 */
+	public function supports(Notification $notification): bool
+	{
+		return strtoupper($notification->getEventCode()) === self::EVENT_CODE;
+	}
+
+	/**
+	 * Actual processing of the notification
+	 *
+	 * @param Notification $notification
+	 * @throws \Doctrine\ORM\ORMException
+	 * @throws \Doctrine\ORM\OptimisticLockException
+	 * @throws \Doctrine\ORM\TransactionRequiredException
+	 * @throws \Enlight_Event_Exception
+	 */
+	public function process(Notification $notification)
+	{
+		$order = $notification->getOrder();
+
+		$this->eventManager->notify(
+			Event::NOTIFICATION_PROCESS_OFFER_CLOSED,
+			[
+				'order' => $order,
+				'notification' => $notification
+			]
+		);
+
+		if ($notification->isSuccess()) {
+			$this->paymentStatusUpdate->updateOrderStatus(
+				$order,
+				Status::ORDER_STATE_CANCELLED_REJECTED
+			);
+			$this->paymentStatusUpdate->updatePaymentStatus(
+				$order,
+				Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED
+			);
+		}
+	}
+}

--- a/Components/PaymentStatusUpdate.php
+++ b/Components/PaymentStatusUpdate.php
@@ -31,53 +31,53 @@ class PaymentStatusUpdate
         $this->modelManager = $modelManager;
     }
 
-	/**
-	 * @param Order $order
-	 * @param int $statusId
-	 * @throws \Doctrine\ORM\ORMException
-	 * @throws \Doctrine\ORM\OptimisticLockException
-	 * @throws \Doctrine\ORM\TransactionRequiredException
-	 */
-	public function updateOrderStatus(Order $order, int $statusId)
-	{
-		$orderStatus = $this->modelManager->find(Status::class, $statusId);
+    /**
+     * @param Order $order
+     * @param int $statusId
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     */
+    public function updateOrderStatus(Order $order, int $statusId)
+    {
+        $orderStatus = $this->modelManager->find(Status::class, $statusId);
 
-		if ($this->logger) {
-			$this->logger->debug('Update order status', [
-				'number' => $order->getNumber(),
-				'oldStatus' => $order->getOrderStatus()->getName(),
-				'newStatus' => $orderStatus->getName()
-			]);
-		}
+        if ($this->logger) {
+            $this->logger->debug('Update order status', [
+                'number' => $order->getNumber(),
+                'oldStatus' => $order->getOrderStatus()->getName(),
+                'newStatus' => $orderStatus->getName()
+            ]);
+        }
 
-		$order->setOrderStatus($orderStatus);
-		$this->modelManager->persist($order);
-		$this->modelManager->flush();
-	}
+        $order->setOrderStatus($orderStatus);
+        $this->modelManager->persist($order);
+        $this->modelManager->flush();
+    }
 
-	/**
-	 * @param Order $order
-	 * @param int $statusId
-	 * @throws \Doctrine\ORM\ORMException
-	 * @throws \Doctrine\ORM\OptimisticLockException
-	 * @throws \Doctrine\ORM\TransactionRequiredException
-	 */
-	public function updatePaymentStatus(Order $order, int $statusId)
-	{
-		$paymentStatus = $this->modelManager->find(Status::class, $statusId);
+    /**
+     * @param Order $order
+     * @param int $statusId
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     */
+    public function updatePaymentStatus(Order $order, int $statusId)
+    {
+        $paymentStatus = $this->modelManager->find(Status::class, $statusId);
 
-		if ($this->logger) {
-			$this->logger->debug('Update order payment status', [
-				'number' => $order->getNumber(),
-				'oldStatus' => $order->getPaymentStatus()->getName(),
-				'newStatus' => $paymentStatus->getName()
-			]);
-		}
+        if ($this->logger) {
+            $this->logger->debug('Update order payment status', [
+                'number' => $order->getNumber(),
+                'oldStatus' => $order->getPaymentStatus()->getName(),
+                'newStatus' => $paymentStatus->getName()
+            ]);
+        }
 
-		$order->setPaymentStatus($paymentStatus);
-		$this->modelManager->persist($order);
-		$this->modelManager->flush();
-	}
+        $order->setPaymentStatus($paymentStatus);
+        $this->modelManager->persist($order);
+        $this->modelManager->flush();
+    }
 
     /**
      * @param LoggerInterface $logger

--- a/Components/PaymentStatusUpdate.php
+++ b/Components/PaymentStatusUpdate.php
@@ -31,29 +31,53 @@ class PaymentStatusUpdate
         $this->modelManager = $modelManager;
     }
 
-    /**
-     * @param Order $order
-     * @param int $statusId
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
-     * @throws \Doctrine\ORM\TransactionRequiredException
-     */
-    public function updatePaymentStatus(Order $order, int $statusId)
-    {
-        $paymentStatus = $this->modelManager->find(Status::class, $statusId);
+	/**
+	 * @param Order $order
+	 * @param int $statusId
+	 * @throws \Doctrine\ORM\ORMException
+	 * @throws \Doctrine\ORM\OptimisticLockException
+	 * @throws \Doctrine\ORM\TransactionRequiredException
+	 */
+	public function updateOrderStatus(Order $order, int $statusId)
+	{
+		$orderStatus = $this->modelManager->find(Status::class, $statusId);
 
-        if ($this->logger) {
-            $this->logger->debug('Update order payment status', [
-                'number' => $order->getNumber(),
-                'oldStatus' => $order->getPaymentStatus()->getName(),
-                'newStatus' => $paymentStatus->getName()
-            ]);
-        }
+		if ($this->logger) {
+			$this->logger->debug('Update order status', [
+				'number' => $order->getNumber(),
+				'oldStatus' => $order->getOrderStatus()->getName(),
+				'newStatus' => $orderStatus->getName()
+			]);
+		}
 
-        $order->setPaymentStatus($paymentStatus);
-        $this->modelManager->persist($order);
-        $this->modelManager->flush();
-    }
+		$order->setOrderStatus($orderStatus);
+		$this->modelManager->persist($order);
+		$this->modelManager->flush();
+	}
+
+	/**
+	 * @param Order $order
+	 * @param int $statusId
+	 * @throws \Doctrine\ORM\ORMException
+	 * @throws \Doctrine\ORM\OptimisticLockException
+	 * @throws \Doctrine\ORM\TransactionRequiredException
+	 */
+	public function updatePaymentStatus(Order $order, int $statusId)
+	{
+		$paymentStatus = $this->modelManager->find(Status::class, $statusId);
+
+		if ($this->logger) {
+			$this->logger->debug('Update order payment status', [
+				'number' => $order->getNumber(),
+				'oldStatus' => $order->getPaymentStatus()->getName(),
+				'newStatus' => $paymentStatus->getName()
+			]);
+		}
+
+		$order->setPaymentStatus($paymentStatus);
+		$this->modelManager->persist($order);
+		$this->modelManager->flush();
+	}
 
     /**
      * @param LoggerInterface $logger

--- a/Models/Event.php
+++ b/Models/Event.php
@@ -17,7 +17,8 @@ class Event
     const NOTIFICATION_PROCESS_CANCELLATION = 'Adyen_Notification_Process_Cancellation';
     const NOTIFICATION_PROCESS_CAPTURE = 'Adyen_Notification_Process_Capture';
     const NOTIFICATION_PROCESS_CAPTURE_FAILED = 'Adyen_Notification_Process_CaptureFailed';
-    const NOTIFICATION_PROCESS_REFUND = 'Adyen_Notification_Process_Refund';
+	const NOTIFICATION_PROCESS_OFFER_CLOSED = 'Adyen_Notification_Process_OfferClosed';
+	const NOTIFICATION_PROCESS_REFUND = 'Adyen_Notification_Process_Refund';
     const NOTIFICATION_PROCESS_REFUND_FAILED = 'Adyen_Notification_Process_RefundFailed';
     const NOTIFICATION_PROCESS_REFUNDED_REVERSED = 'Adyen_Notification_Process_RefundedReversed';
     const NOTIFICATION_PROCESS_CHARGEBACK = 'Adyen_Notification_Process_Chargeback';

--- a/Models/Event.php
+++ b/Models/Event.php
@@ -17,8 +17,8 @@ class Event
     const NOTIFICATION_PROCESS_CANCELLATION = 'Adyen_Notification_Process_Cancellation';
     const NOTIFICATION_PROCESS_CAPTURE = 'Adyen_Notification_Process_Capture';
     const NOTIFICATION_PROCESS_CAPTURE_FAILED = 'Adyen_Notification_Process_CaptureFailed';
-	const NOTIFICATION_PROCESS_OFFER_CLOSED = 'Adyen_Notification_Process_OfferClosed';
-	const NOTIFICATION_PROCESS_REFUND = 'Adyen_Notification_Process_Refund';
+    const NOTIFICATION_PROCESS_OFFER_CLOSED = 'Adyen_Notification_Process_OfferClosed';
+    const NOTIFICATION_PROCESS_REFUND = 'Adyen_Notification_Process_Refund';
     const NOTIFICATION_PROCESS_REFUND_FAILED = 'Adyen_Notification_Process_RefundFailed';
     const NOTIFICATION_PROCESS_REFUNDED_REVERSED = 'Adyen_Notification_Process_RefundedReversed';
     const NOTIFICATION_PROCESS_CHARGEBACK = 'Adyen_Notification_Process_Chargeback';

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -115,13 +115,13 @@
             <argument type="service" id="events"/>
             <argument type="service" id="adyen_payment.components.payment_status_update"/>
         </service>
-		<service id="adyen_payment.components.notification_processor.offer_closed"
-				 class="AdyenPayment\Components\NotificationProcessor\OfferClosed">
-			<tag name="adyen.payment.notificationprocessor"/>
-			<argument type="service" id="adyen_payment.logger.notifications"/>
-			<argument type="service" id="events"/>
-			<argument type="service" id="adyen_payment.components.payment_status_update"/>
-		</service>
+        <service id="adyen_payment.components.notification_processor.offer_closed"
+                 class="AdyenPayment\Components\NotificationProcessor\OfferClosed">
+            <tag name="adyen.payment.notificationprocessor"/>
+            <argument type="service" id="adyen_payment.logger.notifications"/>
+            <argument type="service" id="events"/>
+            <argument type="service" id="adyen_payment.components.payment_status_update"/>
+        </service>
         <service id="adyen_payment.components.notification_processor.refund"
                  class="AdyenPayment\Components\NotificationProcessor\Refund">
             <tag name="adyen.payment.notificationprocessor"/>

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -115,6 +115,13 @@
             <argument type="service" id="events"/>
             <argument type="service" id="adyen_payment.components.payment_status_update"/>
         </service>
+		<service id="adyen_payment.components.notification_processor.offer_closed"
+				 class="AdyenPayment\Components\NotificationProcessor\OfferClosed">
+			<tag name="adyen.payment.notificationprocessor"/>
+			<argument type="service" id="adyen_payment.logger.notifications"/>
+			<argument type="service" id="events"/>
+			<argument type="service" id="adyen_payment.components.payment_status_update"/>
+		</service>
         <service id="adyen_payment.components.notification_processor.refund"
                  class="AdyenPayment\Components\NotificationProcessor\Refund">
             <tag name="adyen.payment.notificationprocessor"/>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adds notification processor for OFFER_CLOSED notification. It changes the order state to cancelled/rejected and the payment state to 'this process has been cancelled'.

## Tested scenarios
Receive offer_closed notification.


**Fixed issue**:  #15 
