### PR TITLE
[PW-2862] Fixing Yandex logo

### DIFF
--- a/Components/PaymentMethodService.php
+++ b/Components/PaymentMethodService.php
@@ -18,6 +18,12 @@ use Shopware_Components_Snippet_Manager;
  */
 class PaymentMethodService
 {
+
+    const PM_LOGO_FILENAME = [
+        'scheme' => 'card',
+        'yandex_money' => 'yandex'
+    ];
+
     /**
      * @var ModelManager
      */
@@ -203,8 +209,9 @@ class PaymentMethodService
      */
     public function getAdyenImageByType($type)
     {
-        if ($type === 'scheme') {
-            $type = 'card';
+        //Some payment method codes don't match the logo filename
+        if (!empty(self::PM_LOGO_FILENAME[$type])) {
+            $type = self::PM_LOGO_FILENAME[$type];
         }
         return sprintf('https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/%s.svg', $type);
     }


### PR DESCRIPTION
# Summary
Since the PM code is being used to fetch the logo image some methods show a broken logo. A constant array was introduced to maintain multiple PMs with this condition.

## Tested scenarios
Yandex Money shows logo.

**Fixed issue**:  PW-2862
