### PR TITLE
Fixes #13 PW-2748 Add event to order restore

### DIFF
--- a/Components/BasketService.php
+++ b/Components/BasketService.php
@@ -118,6 +118,11 @@ class BasketService
         foreach ($orderDetails as $orderDetail) {
             $this->processOrderDetail($order, $orderDetail);
         }
+
+        $this->events->notify(Event::BASKET_RESTORE_FROM_ORDER, [
+            'order' => $order
+        ]);
+
         $this->sBasket->sRefreshBasket();
     }
 

--- a/Models/Event.php
+++ b/Models/Event.php
@@ -23,6 +23,7 @@ class Event
     const NOTIFICATION_PROCESS_CHARGEBACK = 'Adyen_Notification_Process_Chargeback';
     const NOTIFICATION_PROCESS_CHARGEBACK_REVERSED = 'Adyen_Notification_Process_ChargebackReversed';
 
+    const BASKET_RESTORE_FROM_ORDER = 'Adyen_Basket_RestoreFromOrder';
     const BASKET_BEFORE_PROCESS_ORDER_DETAIL = 'Adyen_Basket_Before_ProcessOrderDetail';
     const BASKET_STOPPED_PROCESS_ORDER_DETAIL = 'Adyen_Basket_Stopped_ProcessOrderDetail';
     const BASKET_AFTER_PROCESS_ORDER_DETAIL = 'Adyen_Basket_After_ProcessOrderDetail';


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Adds an Adyen_Basket_RestoreFromOrder event that is triggered when a payment is cancelled and the basket has to be rebuild from the previous order.
It is not possible to copy custom fields from the old order to a new basket, so this event provides an entry point for other developers to do their magic.

**Fixed issue**:  #13 PW-2748