### PR TITLE
Only send mail after succesful payment

### DIFF
--- a/AdyenPayment.php
+++ b/AdyenPayment.php
@@ -18,6 +18,7 @@ use Shopware\Components\Plugin\Context\ActivateContext;
 use Shopware\Components\Plugin\Context\DeactivateContext;
 use Shopware\Components\Plugin\Context\InstallContext;
 use Shopware\Components\Plugin\Context\UninstallContext;
+use Shopware\Components\Plugin\Context\UpdateContext;
 use Shopware\Components\Plugin\PaymentInstaller;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -36,6 +37,7 @@ class AdyenPayment extends Plugin
     const SESSION_ADYEN_PAYMENT = 'adyenPayment';
     const SESSION_ADYEN_PAYMENT_VALID = 'adyenPaymentValid';
     const SESSION_ADYEN_PAYMENT_DATA = 'adyenPaymentData';
+	const SESSION_ADYEN_RESTRICT_EMAILS = 'adyenRestrictEmail';
 
     /**
      * @return bool
@@ -95,7 +97,18 @@ class AdyenPayment extends Plugin
         $tool->updateSchema($classes, true);
     }
 
-    /**
+    public function update(UpdateContext $context)
+	{
+		$this->installAttributes();
+
+		$tool = new SchemaTool($this->container->get('models'));
+		$classes = $this->getModelMetaData();
+		$tool->updateSchema($classes, true);
+
+		parent::update($context);
+	}
+
+	/**
      * @param UninstallContext $context
      * @throws Exception
      */

--- a/AdyenPayment.php
+++ b/AdyenPayment.php
@@ -37,7 +37,7 @@ class AdyenPayment extends Plugin
     const SESSION_ADYEN_PAYMENT = 'adyenPayment';
     const SESSION_ADYEN_PAYMENT_VALID = 'adyenPaymentValid';
     const SESSION_ADYEN_PAYMENT_DATA = 'adyenPaymentData';
-	const SESSION_ADYEN_RESTRICT_EMAILS = 'adyenRestrictEmail';
+    const SESSION_ADYEN_RESTRICT_EMAILS = 'adyenRestrictEmail';
 
     /**
      * @return bool
@@ -98,17 +98,17 @@ class AdyenPayment extends Plugin
     }
 
     public function update(UpdateContext $context)
-	{
-		$this->installAttributes();
+    {
+        $this->installAttributes();
 
-		$tool = new SchemaTool($this->container->get('models'));
-		$classes = $this->getModelMetaData();
-		$tool->updateSchema($classes, true);
+        $tool = new SchemaTool($this->container->get('models'));
+        $classes = $this->getModelMetaData();
+        $tool->updateSchema($classes, true);
 
-		parent::update($context);
-	}
+        parent::update($context);
+    }
 
-	/**
+    /**
      * @param UninstallContext $context
      * @throws Exception
      */

--- a/Components/OrderMailService.php
+++ b/Components/OrderMailService.php
@@ -6,55 +6,55 @@ use Shopware\Components\Model\ModelManager;
 
 class OrderMailService
 {
-	/**
-	 * @var ModelManager
-	 */
-	private $modelManager;
-	/**
-	 * @var BasketService
-	 */
-	private $basketService;
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+    /**
+     * @var BasketService
+     */
+    private $basketService;
 
-	public function __construct(
-		ModelManager $modelManager,
-		BasketService $basketService
-	) {
-		$this->modelManager = $modelManager;
-		$this->basketService = $basketService;
-	}
+    public function __construct(
+        ModelManager $modelManager,
+        BasketService $basketService
+    ) {
+        $this->modelManager = $modelManager;
+        $this->basketService = $basketService;
+    }
 
-	/**
-	 * Sends the mail after a payment is confirmed
-	 *
-	 * @param \Shopware\Models\Order\Order $order
-	 */
-	public function sendOrderConfirmationMail($orderNumber)
-	{
-		$order = $this->basketService->getOrderByOrderNumber($orderNumber);
-		if (!$order) {
-			return;
-		}
+    /**
+     * Sends the mail after a payment is confirmed
+     *
+     * @param \Shopware\Models\Order\Order $order
+     */
+    public function sendOrderConfirmationMail($orderNumber)
+    {
+        $order = $this->basketService->getOrderByOrderNumber($orderNumber);
+        if (!$order) {
+            return;
+        }
 
-		$paymentInfoRepository = $this->modelManager->getRepository(\AdyenPayment\Models\PaymentInfo::class);
-		/** @var \AdyenPayment\Models\PaymentInfo $paymentInfo */
-		$paymentInfo = $paymentInfoRepository->findOneBy([
-			'orderId' => $order->getId()
-		]);
+        $paymentInfoRepository = $this->modelManager->getRepository(\AdyenPayment\Models\PaymentInfo::class);
+        /** @var \AdyenPayment\Models\PaymentInfo $paymentInfo */
+        $paymentInfo = $paymentInfoRepository->findOneBy([
+            'orderId' => $order->getId()
+        ]);
 
-		if (!$paymentInfo) {
-			return;
-		}
+        if (!$paymentInfo) {
+            return;
+        }
 
-		$variables = json_decode($paymentInfo->getOrdermailVariables(), true);
+        $variables = json_decode($paymentInfo->getOrdermailVariables(), true);
 
-		if (is_array($variables)) {
-			$sOrder = Shopware()->Modules()->Order();
-			$sOrder->sUserData = $variables;
-			$sOrder->sendMail($variables);
-		}
+        if (is_array($variables)) {
+            $sOrder = Shopware()->Modules()->Order();
+            $sOrder->sUserData = $variables;
+            $sOrder->sendMail($variables);
+        }
 
-		$paymentInfo->setOrdermailVariables(null);
-		$this->modelManager->persist($paymentInfo);
-		$this->modelManager->flush($paymentInfo);
-	}
+        $paymentInfo->setOrdermailVariables(null);
+        $this->modelManager->persist($paymentInfo);
+        $this->modelManager->flush($paymentInfo);
+    }
 }

--- a/Components/OrderMailService.php
+++ b/Components/OrderMailService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace AdyenPayment\Components;
+
+use Shopware\Components\Model\ModelManager;
+
+class OrderMailService
+{
+	/**
+	 * @var ModelManager
+	 */
+	private $modelManager;
+	/**
+	 * @var BasketService
+	 */
+	private $basketService;
+
+	public function __construct(
+		ModelManager $modelManager,
+		BasketService $basketService
+	) {
+		$this->modelManager = $modelManager;
+		$this->basketService = $basketService;
+	}
+
+	/**
+	 * Sends the mail after a payment is confirmed
+	 *
+	 * @param \Shopware\Models\Order\Order $order
+	 */
+	public function sendOrderConfirmationMail($orderNumber)
+	{
+		$order = $this->basketService->getOrderByOrderNumber($orderNumber);
+		if (!$order) {
+			return;
+		}
+
+		$paymentInfoRepository = $this->modelManager->getRepository(\AdyenPayment\Models\PaymentInfo::class);
+		/** @var \AdyenPayment\Models\PaymentInfo $paymentInfo */
+		$paymentInfo = $paymentInfoRepository->findOneBy([
+			'orderId' => $order->getId()
+		]);
+
+		if (!$paymentInfo) {
+			return;
+		}
+
+		$variables = json_decode($paymentInfo->getOrdermailVariables(), true);
+
+		if (is_array($variables)) {
+			$sOrder = Shopware()->Modules()->Order();
+			$sOrder->sUserData = $variables;
+			$sOrder->sendMail($variables);
+		}
+
+		$paymentInfo->setOrdermailVariables(null);
+		$this->modelManager->persist($paymentInfo);
+		$this->modelManager->flush($paymentInfo);
+	}
+}

--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -207,9 +207,9 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
      */
     private function prepareOrder($transaction)
     {
-    	$signature = $this->persistBasket();
+        $signature = $this->persistBasket();
 
-    	Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, $transaction->getId());
+        Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, $transaction->getId());
 
         $orderNumber = $this->saveOrder(
             $transaction->getId(),
@@ -218,7 +218,7 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
             false
         );
 
-		Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, false);
+        Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, false);
 
         /** @var Order $order */
         $order = $this->getModelManager()->getRepository(Order::class)->findOneBy([

--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -1,5 +1,6 @@
 <?php
 
+use AdyenPayment\AdyenPayment;
 use AdyenPayment\Components\Adyen\PaymentMethodService;
 use AdyenPayment\Components\BasketService;
 use AdyenPayment\Components\Calculator\PriceCalculationService;
@@ -199,14 +200,16 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
     }
 
     /**
-     * @param $transaction
+     * @param PaymentInfo $transaction
      * @return Order
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      */
     private function prepareOrder($transaction)
     {
-        $signature = $this->persistBasket();
+    	$signature = $this->persistBasket();
+
+    	Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, $transaction->getId());
 
         $orderNumber = $this->saveOrder(
             $transaction->getId(),
@@ -214,6 +217,8 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
             Status::PAYMENT_STATE_OPEN,
             false
         );
+
+		Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, false);
 
         /** @var Order $order */
         $order = $this->getModelManager()->getRepository(Order::class)->findOneBy([

--- a/Controllers/Frontend/Process.php
+++ b/Controllers/Frontend/Process.php
@@ -28,10 +28,10 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
      */
     private $basketService;
 
-	/**
-	 * @var \AdyenPayment\Components\OrderMailService
-	 */
-	private $orderMailService;
+    /**
+     * @var \AdyenPayment\Components\OrderMailService
+     */
+    private $orderMailService;
 
     /**
      * @var Logger
@@ -39,7 +39,7 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
     private $logger;
 
 
-	/**
+    /**
      * Whitelist notifyAction
      */
     public function getWhitelistedCSRFActions()
@@ -51,8 +51,8 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
     {
         $this->adyenManager = $this->get('adyen_payment.components.manager.adyen_manager');
         $this->adyenCheckout = $this->get('adyen_payment.components.adyen.payment.method');
-		$this->basketService = $this->get('adyen_payment.components.basket_service');
-		$this->orderMailService = $this->get('adyen_payment.components.order_mail_service');
+        $this->basketService = $this->get('adyen_payment.components.basket_service');
+        $this->orderMailService = $this->get('adyen_payment.components.order_mail_service');
         $this->logger = $this->get('adyen_payment.logger');
     }
 
@@ -70,12 +70,12 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
             $this->handleReturnResult($result);
 
             switch ($result['resultCode']) {
-				case PaymentResultCodes::AUTHORISED:
-				case PaymentResultCodes::PENDING:
-				case PaymentResultCodes::RECEIVED:
-					if (!empty($result['merchantReference'])) {
-						$this->orderMailService->sendOrderConfirmationMail($result['merchantReference']);
-					}
+                case PaymentResultCodes::AUTHORISED:
+                case PaymentResultCodes::PENDING:
+                case PaymentResultCodes::RECEIVED:
+                    if (!empty($result['merchantReference'])) {
+                        $this->orderMailService->sendOrderConfirmationMail($result['merchantReference']);
+                    }
                     $this->redirect([
                         'controller' => 'checkout',
                         'action' => 'finish',

--- a/Models/PaymentInfo.php
+++ b/Models/PaymentInfo.php
@@ -52,15 +52,19 @@ class PaymentInfo extends ModelEntity
      */
     private $updatedAt;
 
-    /**
-     * @var string
-     * @ORM\Column(name="result_code", type="text", nullable=true)
-     */
-    private $resultCode;
+	/**
+	 * @var string
+	 * @ORM\Column(name="result_code", type="text", nullable=true)
+	 */
+	private $resultCode;
 
-    /**
-     * PaymenntInfo constructor
-     */
+	/**
+	 * @var string
+	 *
+	 * @ORM\Column(name="ordermail_variables", type="text", nullable=true)
+	 */
+	private $ordermailVariables;
+
     public function __construct()
     {
         $this->setCreatedAt(new \DateTime('now'));
@@ -195,4 +199,22 @@ class PaymentInfo extends ModelEntity
         $this->resultCode = $resultCode;
         return $this;
     }
+
+	/**
+	 * @return string|null
+	 */
+	public function getOrdermailVariables()
+	{
+		return $this->ordermailVariables;
+	}
+
+	/**
+	 * @param string|null $ordermailVariables
+	 * @return $this
+	 */
+	public function setOrdermailVariables($ordermailVariables)
+	{
+		$this->ordermailVariables = $ordermailVariables;
+		return $this;
+	}
 }

--- a/Models/PaymentInfo.php
+++ b/Models/PaymentInfo.php
@@ -52,18 +52,18 @@ class PaymentInfo extends ModelEntity
      */
     private $updatedAt;
 
-	/**
-	 * @var string
-	 * @ORM\Column(name="result_code", type="text", nullable=true)
-	 */
-	private $resultCode;
+    /**
+     * @var string
+     * @ORM\Column(name="result_code", type="text", nullable=true)
+     */
+    private $resultCode;
 
-	/**
-	 * @var string
-	 *
-	 * @ORM\Column(name="ordermail_variables", type="text", nullable=true)
-	 */
-	private $ordermailVariables;
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="ordermail_variables", type="text", nullable=true)
+     */
+    private $ordermailVariables;
 
     public function __construct()
     {
@@ -200,21 +200,21 @@ class PaymentInfo extends ModelEntity
         return $this;
     }
 
-	/**
-	 * @return string|null
-	 */
-	public function getOrdermailVariables()
-	{
-		return $this->ordermailVariables;
-	}
+    /**
+     * @return string|null
+     */
+    public function getOrdermailVariables()
+    {
+        return $this->ordermailVariables;
+    }
 
-	/**
-	 * @param string|null $ordermailVariables
-	 * @return $this
-	 */
-	public function setOrdermailVariables($ordermailVariables)
-	{
-		$this->ordermailVariables = $ordermailVariables;
-		return $this;
-	}
+    /**
+     * @param string|null $ordermailVariables
+     * @return $this
+     */
+    public function setOrdermailVariables($ordermailVariables)
+    {
+        $this->ordermailVariables = $ordermailVariables;
+        return $this;
+    }
 }

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -15,14 +15,14 @@
             <argument type="service" id="events"/>
             <argument type="service" id="models"/>
         </service>
-		<service id="adyen_payment.components.configuration" class="AdyenPayment\Components\Configuration">
-			<argument type="service" id="shopware.plugin.cached_config_reader"/>
-			<argument type="service" id="dbal_connection"/>
-		</service>
-		<service id="adyen_payment.components.order_mail_service" class="AdyenPayment\Components\OrderMailService">
-			<argument type="service" id="models"/>
-			<argument type="service" id="adyen_payment.components.basket_service"/>
-		</service>
+        <service id="adyen_payment.components.configuration" class="AdyenPayment\Components\Configuration">
+            <argument type="service" id="shopware.plugin.cached_config_reader"/>
+            <argument type="service" id="dbal_connection"/>
+        </service>
+        <service id="adyen_payment.components.order_mail_service" class="AdyenPayment\Components\OrderMailService">
+            <argument type="service" id="models"/>
+            <argument type="service" id="adyen_payment.components.basket_service"/>
+        </service>
         <service id="adyen_payment.components.adyen.apifactory" class="AdyenPayment\Components\Adyen\ApiFactory">
             <argument type="service" id="models"/>
             <argument type="service" id="adyen_payment.components.configuration"/>

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -15,10 +15,14 @@
             <argument type="service" id="events"/>
             <argument type="service" id="models"/>
         </service>
-        <service id="adyen_payment.components.configuration" class="AdyenPayment\Components\Configuration">
-            <argument type="service" id="shopware.plugin.cached_config_reader"/>
-            <argument type="service" id="dbal_connection"/>
-        </service>
+		<service id="adyen_payment.components.configuration" class="AdyenPayment\Components\Configuration">
+			<argument type="service" id="shopware.plugin.cached_config_reader"/>
+			<argument type="service" id="dbal_connection"/>
+		</service>
+		<service id="adyen_payment.components.order_mail_service" class="AdyenPayment\Components\OrderMailService">
+			<argument type="service" id="models"/>
+			<argument type="service" id="adyen_payment.components.basket_service"/>
+		</service>
         <service id="adyen_payment.components.adyen.apifactory" class="AdyenPayment\Components\Adyen\ApiFactory">
             <argument type="service" id="models"/>
             <argument type="service" id="adyen_payment.components.configuration"/>

--- a/Resources/services/subscribers.xml
+++ b/Resources/services/subscribers.xml
@@ -33,16 +33,16 @@
             <argument type="service" id="adyen_payment.components.adyen.payment.method"/>
             <argument type="service" id="adyen_payment.components.payment_method_service"/>
         </service>
-		<service id="adyen_payment.subscriber.backend_order_subscriber" class="AdyenPayment\Subscriber\BackendOrderSubscriber">
-			<tag name="shopware.event_subscriber"/>
-			<argument type="service" id="models"/>
-			<argument type="service" id="adyen_payment.components.notification_manager"/>
-		</service>
-		<service id="adyen_payment.subscriber.order_email_subscriber" class="AdyenPayment\Subscriber\OrderEmailSubscriber">
-			<tag name="shopware.event_subscriber"/>
-			<argument type="service" id="models"/>
-			<argument type="service" id="adyen_payment.components.order_mail_service"/>
-		</service>
+        <service id="adyen_payment.subscriber.backend_order_subscriber" class="AdyenPayment\Subscriber\BackendOrderSubscriber">
+            <tag name="shopware.event_subscriber"/>
+            <argument type="service" id="models"/>
+            <argument type="service" id="adyen_payment.components.notification_manager"/>
+        </service>
+        <service id="adyen_payment.subscriber.order_email_subscriber" class="AdyenPayment\Subscriber\OrderEmailSubscriber">
+            <tag name="shopware.event_subscriber"/>
+            <argument type="service" id="models"/>
+            <argument type="service" id="adyen_payment.components.order_mail_service"/>
+        </service>
         <service id="adyen_payment.subscriber.checkout" class="AdyenPayment\Subscriber\CheckoutSubscriber">
             <tag name="shopware.event_subscriber"/>
             <argument type="service" id="adyen_payment.components.configuration"/>

--- a/Resources/services/subscribers.xml
+++ b/Resources/services/subscribers.xml
@@ -33,11 +33,16 @@
             <argument type="service" id="adyen_payment.components.adyen.payment.method"/>
             <argument type="service" id="adyen_payment.components.payment_method_service"/>
         </service>
-        <service id="adyen_payment.subscriber.backend_order_subscriber" class="AdyenPayment\Subscriber\BackendOrderSubscriber">
-            <tag name="shopware.event_subscriber"/>
-            <argument type="service" id="models"/>
-            <argument type="service" id="adyen_payment.components.notification_manager"/>
-        </service>
+		<service id="adyen_payment.subscriber.backend_order_subscriber" class="AdyenPayment\Subscriber\BackendOrderSubscriber">
+			<tag name="shopware.event_subscriber"/>
+			<argument type="service" id="models"/>
+			<argument type="service" id="adyen_payment.components.notification_manager"/>
+		</service>
+		<service id="adyen_payment.subscriber.order_email_subscriber" class="AdyenPayment\Subscriber\OrderEmailSubscriber">
+			<tag name="shopware.event_subscriber"/>
+			<argument type="service" id="models"/>
+			<argument type="service" id="adyen_payment.components.order_mail_service"/>
+		</service>
         <service id="adyen_payment.subscriber.checkout" class="AdyenPayment\Subscriber\CheckoutSubscriber">
             <tag name="shopware.event_subscriber"/>
             <argument type="service" id="adyen_payment.components.configuration"/>

--- a/Subscriber/OrderEmailSubscriber.php
+++ b/Subscriber/OrderEmailSubscriber.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace AdyenPayment\Subscriber;
+
+use AdyenPayment\AdyenPayment;
+use AdyenPayment\Components\NotificationManager;
+use AdyenPayment\Components\OrderMailService;
+use AdyenPayment\Models\PaymentInfo;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityRepository;
+use Enlight\Event\SubscriberInterface;
+use Enlight_Event_EventArgs;
+use MollieShopware\Models\Transaction;
+use Shopware\Components\HttpClient\Response;
+use Shopware\Components\Model\ModelManager;
+use Shopware_Controllers_Frontend_Checkout;
+
+class OrderEmailSubscriber implements SubscriberInterface
+{
+	/**
+	 * @var ModelManager
+	 */
+	private $modelManager;
+
+	/**
+	 * @var ObjectRepository|EntityRepository
+	 */
+	private $paymentInfoRepository;
+	/**
+	 * @var OrderMailService
+	 */
+	private $orderMailService;
+
+	public function __construct(
+		ModelManager $modelManager,
+		OrderMailService $orderMailService
+	) {
+		$this->modelManager = $modelManager;
+		$this->paymentInfoRepository = $this->modelManager->getRepository(PaymentInfo::class);
+		$this->orderMailService = $orderMailService;
+	}
+
+	public static function getSubscribedEvents()
+	{
+		return [
+			'Shopware_Modules_Order_SendMail_Send' => 'shouldStopEmailSending',
+			'Enlight_Controller_Action_PostDispatch_Frontend_Checkout' => 'onCheckoutDispatch'
+		];
+	}
+
+	public function shouldStopEmailSending(Enlight_Event_EventArgs $args) {
+		$orderId = $args->get('orderId');
+		$variables = $args->get('variables');
+
+		if ($variables['additional']['payment']['name'] === AdyenPayment::ADYEN_GENERAL_PAYMENT_METHOD &&
+			Shopware()->Session()->get(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, true) === false){
+			Shopware()->Session()->offsetSet(AdyenPayment::SESSION_ADYEN_RESTRICT_EMAILS, true);
+
+			/** @var PaymentInfo $paymentInfo */
+			$paymentInfo = $this->paymentInfoRepository->findOneBy([
+				'orderId' => $orderId
+			]);
+
+			if ($paymentInfo && empty($paymentInfo->getOrdermailVariables())) {
+				$paymentInfo->setOrdermailVariables(json_encode($variables));
+
+				$this->modelManager->persist($paymentInfo);
+				$this->modelManager->flush($paymentInfo);
+			}
+
+			return false;
+		}
+
+		return null;
+	}
+
+	public function onCheckoutDispatch(Enlight_Event_EventArgs $args) {
+
+		/** @var Shopware_Controllers_Frontend_Checkout $subject */
+		$subject = $args->getSubject();
+
+		if ($subject->Request()->getActionName() !== 'finish') {
+			return;
+		}
+
+		$data = $subject->View()->getAssign();
+
+		if (!$data['sOrderNumber']) {
+			return;
+		}
+
+		$this->orderMailService->sendOrderConfirmationMail($data['sOrderNumber']);
+	}
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <label>Adyen Shopware Plugin</label>
     <label lang="de">Adyen Shopware Plugin</label>
 
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <copyright>Adyen</copyright>
     <author>Adyen</author>
     <link>https://adyen.com</link>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Disabled sending email before payment and sends it when payment is succesfull.

## Tested scenarios
Payment with CC: failed, success
Paymetn with sofort: failed, success


**Fixed issue**:  #12
