### PR TITLE
Feature/change refund function

### DIFF
--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -77,4 +77,25 @@ class NotificationManager
             return null;
         }
     }
+
+    /**
+     * @param string $pspReference
+     * @return mixed|null
+     * @throws NonUniqueResultException
+     */
+    public function getLastNotificationForPspReference(string $pspReference)
+    {
+        try {
+            $lastNotification = $this->notificationRepository->createQueryBuilder('n')
+                ->where('n.pspReference = :pspReference')
+                ->setMaxResults(1)
+                ->orderBy('n.createdAt', 'ASC')
+                ->setParameter('pspReference', $pspReference)
+                ->getQuery()
+                ->getSingleResult();
+            return $lastNotification;
+        } catch (NoResultException $ex) {
+            return null;
+        }
+    }
 }

--- a/Components/NotificationProcessor/Authorisation.php
+++ b/Components/NotificationProcessor/Authorisation.php
@@ -31,16 +31,16 @@ class Authorisation implements NotificationProcessorInterface
      * @var PaymentStatusUpdate
      */
     private $paymentStatusUpdate;
-	/**
-	 * @var ModelManager
-	 */
-	private $modelManager;
-	/**
-	 * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
-	 */
-	private $paymentInfoRepository;
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+    /**
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
+     */
+    private $paymentInfoRepository;
 
-	/**
+    /**
      * Authorisation constructor.
      * @param LoggerInterface $logger
      * @param ContainerAwareEventManager $eventManager
@@ -50,14 +50,14 @@ class Authorisation implements NotificationProcessorInterface
         LoggerInterface $logger,
         ContainerAwareEventManager $eventManager,
         PaymentStatusUpdate $paymentStatusUpdate,
-		ModelManager $modelManager
+        ModelManager $modelManager
     ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
-		$this->modelManager = $modelManager;
-		$this->paymentInfoRepository = $modelManager->getRepository(PaymentInfo::class);
-	}
+        $this->modelManager = $modelManager;
+        $this->paymentInfoRepository = $modelManager->getRepository(PaymentInfo::class);
+    }
 
     /**
      * Returns boolean on whether this processor can process the Notification object
@@ -97,14 +97,14 @@ class Authorisation implements NotificationProcessorInterface
         $this->paymentStatusUpdate->updatePaymentStatus($order, $status);
 
         if ($notification->isSuccess()) {
-        	/** @var PaymentInfo $paymentInfo */
-        	$paymentInfo = $this->paymentInfoRepository->findOneBy([
-        		'orderId' => $order->getId()
-			]);
+            /** @var PaymentInfo $paymentInfo */
+            $paymentInfo = $this->paymentInfoRepository->findOneBy([
+                'orderId' => $order->getId()
+            ]);
 
-        	$paymentInfo->setPspReference($notification->getPspReference());
-        	$this->modelManager->persist($paymentInfo);
-        	$this->modelManager->flush($paymentInfo);
-		}
+            $paymentInfo->setPspReference($notification->getPspReference());
+            $this->modelManager->persist($paymentInfo);
+            $this->modelManager->flush($paymentInfo);
+        }
     }
 }

--- a/Components/NotificationProcessor/Authorisation.php
+++ b/Components/NotificationProcessor/Authorisation.php
@@ -5,8 +5,10 @@ namespace AdyenPayment\Components\NotificationProcessor;
 use AdyenPayment\Components\PaymentStatusUpdate;
 use AdyenPayment\Models\Event;
 use AdyenPayment\Models\Notification;
+use AdyenPayment\Models\PaymentInfo;
 use Psr\Log\LoggerInterface;
 use Shopware\Components\ContainerAwareEventManager;
+use Shopware\Components\Model\ModelManager;
 use Shopware\Models\Order\Status;
 
 /**
@@ -29,8 +31,16 @@ class Authorisation implements NotificationProcessorInterface
      * @var PaymentStatusUpdate
      */
     private $paymentStatusUpdate;
+	/**
+	 * @var ModelManager
+	 */
+	private $modelManager;
+	/**
+	 * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
+	 */
+	private $paymentInfoRepository;
 
-    /**
+	/**
      * Authorisation constructor.
      * @param LoggerInterface $logger
      * @param ContainerAwareEventManager $eventManager
@@ -39,12 +49,15 @@ class Authorisation implements NotificationProcessorInterface
     public function __construct(
         LoggerInterface $logger,
         ContainerAwareEventManager $eventManager,
-        PaymentStatusUpdate $paymentStatusUpdate
+        PaymentStatusUpdate $paymentStatusUpdate,
+		ModelManager $modelManager
     ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
-    }
+		$this->modelManager = $modelManager;
+		$this->paymentInfoRepository = $modelManager->getRepository(PaymentInfo::class);
+	}
 
     /**
      * Returns boolean on whether this processor can process the Notification object
@@ -82,5 +95,16 @@ class Authorisation implements NotificationProcessorInterface
             Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED;
 
         $this->paymentStatusUpdate->updatePaymentStatus($order, $status);
+
+        if ($notification->isSuccess()) {
+        	/** @var PaymentInfo $paymentInfo */
+        	$paymentInfo = $this->paymentInfoRepository->findOneBy([
+        		'orderId' => $order->getId()
+			]);
+
+        	$paymentInfo->setPspReference($notification->getPspReference());
+        	$this->modelManager->persist($paymentInfo);
+        	$this->modelManager->flush($paymentInfo);
+		}
     }
 }

--- a/Components/NotificationProcessor/Capture.php
+++ b/Components/NotificationProcessor/Capture.php
@@ -35,17 +35,17 @@ class Capture implements NotificationProcessorInterface
      * @var PaymentStatusUpdate
      */
     private $paymentStatusUpdate;
-	/**
-	 * @var ModelManager
-	 */
-	private $modelManager;
-	/**
-	 * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
-	 */
-	private $paymentInfoRepository;
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+    /**
+     * @var \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository
+     */
+    private $paymentInfoRepository;
 
 
-	/**
+    /**
      * Capture constructor.
      * @param LoggerInterface $logger
      * @param ContainerAwareEventManager $eventManager
@@ -55,14 +55,14 @@ class Capture implements NotificationProcessorInterface
         LoggerInterface $logger,
         ContainerAwareEventManager $eventManager,
         PaymentStatusUpdate $paymentStatusUpdate,
-		ModelManager $modelManager
+        ModelManager $modelManager
     ) {
         $this->logger = $logger;
         $this->eventManager = $eventManager;
         $this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
-		$this->modelManager = $modelManager;
-		$this->paymentInfoRepository = $modelManager->getRepository(PaymentInfo::class);
-	}
+        $this->modelManager = $modelManager;
+        $this->paymentInfoRepository = $modelManager->getRepository(PaymentInfo::class);
+    }
 
     /**
      * Returns boolean on whether this processor can process the Notification object
@@ -101,14 +101,14 @@ class Capture implements NotificationProcessorInterface
                 Status::PAYMENT_STATE_COMPLETELY_PAID
             );
 
-			/** @var PaymentInfo $paymentInfo */
-			$paymentInfo = $this->paymentInfoRepository->findOneBy([
-				'orderId' => $order->getId()
-			]);
+            /** @var PaymentInfo $paymentInfo */
+            $paymentInfo = $this->paymentInfoRepository->findOneBy([
+                'orderId' => $order->getId()
+            ]);
 
-			$paymentInfo->setPspReference($notification->getPspReference());
-			$this->modelManager->persist($paymentInfo);
-			$this->modelManager->flush($paymentInfo);
+            $paymentInfo->setPspReference($notification->getPspReference());
+            $this->modelManager->persist($paymentInfo);
+            $this->modelManager->flush($paymentInfo);
         }
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Saves the PSP Reference of a successful notification to the PaymentInfo object so refunds can be made with the correct psp reference, even if a faulty notification comes in later.

**Fixed issue**:  #17 
