### PR TITLE
add redirect  data to payments request

### DIFF
--- a/Components/Payload/Providers/ApplicationInfoProvider.php
+++ b/Components/Payload/Providers/ApplicationInfoProvider.php
@@ -49,8 +49,10 @@ class ApplicationInfoProvider implements PaymentPayloadProvider
                 'executeThreeD' => true,
                 'allow3DS2' => true,
             ],
-            "channel" => Channel::WEB,
+            'channel' => Channel::WEB,
             'origin' => $context->getOrigin(),
+            'redirectFromIssuerMethod' => 'GET',
+            'redirectToIssuerMethod' => 'POST',
             'returnUrl' => $returnUrl,
             'merchantAccount' => $this->configuration->getMerchantAccount(),
             'applicationInfo' => [

--- a/Components/Payload/Providers/OrderInfoProvider.php
+++ b/Components/Payload/Providers/OrderInfoProvider.php
@@ -23,8 +23,8 @@ class OrderInfoProvider implements PaymentPayloadProvider
 
         return [
             'amount' => [
-                "currency" => $currencyCode,
-                "value" => $adyenCurrency->sanitize($context->getOrder()->getInvoiceAmount(), $currencyCode),
+                'currency' => $currencyCode,
+                'value' => $adyenCurrency->sanitize($context->getOrder()->getInvoiceAmount(), $currencyCode),
             ],
             'reference' => $context->getOrder()->getNumber(),
         ];


### PR DESCRIPTION
## Summary
The SameSite cookie security feature being rolled out by browsers breaks the session on 3DS1 auth redirecting back to the shop.

Using Adyen's `redirectFromIssuerMethod=GET`, `redirectToIssuerMethod=POST` and `returnUrl` parameters on the `/payments` request would avoid a redirect back using POST.

## Tested scenarios
Data added to payment request 

**Fixed issue**:  #51 
