### PR TITLE
Ap 59 gift card

### DIFF
--- a/Resources/frontend/js/jquery.adyen-payment-selection.js
+++ b/Resources/frontend/js/jquery.adyen-payment-selection.js
@@ -157,6 +157,17 @@
                 return paymentMethod.type === pmType
             });
         },
+        /**
+         * @param {String} paymentType
+         * @param {String} detailKey
+         * @return {({} | null)}
+         * @private
+         */
+        __retrievePaymentMethodDetailByKey(paymentType, detailKey) {
+            const me = this;
+            return me.getPaymentMethodByType(paymentType)?.details
+                ?.find(detail => detail.key === detailKey);
+        },
         setCheckout: function () {
             var me = this;
 
@@ -187,10 +198,12 @@
         },
         handleGiftCardComponent: function (giftCardType) {
             const me = this;
+            const pinRequiredDetail = me.__retrievePaymentMethodDetailByKey(giftCardType, 'encryptedSecurityCode');
+
             me.adyenCheckout
                 .create('giftcard', {
                     type: giftCardType,
-                    pinRequired: true   // @todo: get setting from giftcard data
+                    pinRequired: false === pinRequiredDetail?.optional
                 })
                 .mount('#' + me.getCurrentComponentId(me.currentSelectedPaymentId));
         },

--- a/Resources/frontend/js/jquery.adyen-payment-selection.js
+++ b/Resources/frontend/js/jquery.adyen-payment-selection.js
@@ -166,8 +166,7 @@
             var me = this;
 
             if (me.__isGiftCardType(type)) {
-                me.handleComponentGeneral(type);
-                // me.handleGiftCard(type);
+                me.handleGiftCardComponent(type);
                 return;
             }
 
@@ -185,6 +184,15 @@
         handleComponentPayWithGoogle: function (type) {
             var me = this;
             $(me.opts.paymentMethodFormSubmitSelector).removeClass('is--disabled');
+        },
+        handleGiftCardComponent: function (giftCardType) {
+            const me = this;
+            me.adyenCheckout
+                .create('giftcard', {
+                    type: giftCardType,
+                    pinRequired: true   // @todo: get setting from giftcard data
+                })
+                .mount('#' + me.getCurrentComponentId(me.currentSelectedPaymentId));
         },
         handleOnChange: function (state) {
             var me = this;
@@ -303,16 +311,16 @@
             me.sessionStorage.setItem(me.adyenConfigSession, JSON.stringify(data));
         },
         /**
-         * @param {string} type
+         * @param {string} paymentType
          * @return {boolean}
          * @private
          */
-        __isGiftCardType(type) {
+        __isGiftCardType(paymentType) {
             const giftCardGroup = this.opts.adyenPaymentMethodsResponse['groups']?.find(
                 group => this.defaults.giftCardGroupName === group['name']
             ) ?? {};
 
-            return (giftCardGroup['types'] ?? []).includes(type);
+            return (giftCardGroup['types'] ?? []).includes(paymentType);
         },
     });
 

--- a/Resources/frontend/js/jquery.adyen-payment-selection.js
+++ b/Resources/frontend/js/jquery.adyen-payment-selection.js
@@ -61,6 +61,10 @@
              * @type {String}
              */
             paymentMethodFormSubmitSelector: 'button[type=submit]',
+            /**
+             * @type {string} the group name of Gift card types
+             */
+            giftCardGroupName: 'Gift Card',
         },
 
         currentSelectedPaymentId: '',
@@ -161,14 +165,18 @@
         handleComponent: function (type) {
             var me = this;
 
-            switch (type) {
-                case 'paywithgoogle':
-                    me.handleComponentPayWithGoogle(type);
-                    break;
-                default:
-                    me.handleComponentGeneral(type);
-                    break;
+            if (me.__isGiftCardType(type)) {
+                me.handleComponentGeneral(type);
+                // me.handleGiftCard(type);
+                return;
             }
+
+            if ('paywithgoogle' === type) {
+                me.handleComponentPayWithGoogle(type);
+                return;
+            }
+
+            me.handleComponentGeneral(type);
         },
         handleComponentGeneral: function (type) {
             var me = this;
@@ -293,6 +301,18 @@
             };
 
             me.sessionStorage.setItem(me.adyenConfigSession, JSON.stringify(data));
+        },
+        /**
+         * @param {string} type
+         * @return {boolean}
+         * @private
+         */
+        __isGiftCardType(type) {
+            const giftCardGroup = this.opts.adyenPaymentMethodsResponse['groups']?.find(
+                group => this.defaults.giftCardGroupName === group['name']
+            ) ?? {};
+
+            return (giftCardGroup['types'] ?? []).includes(type);
         },
     });
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
This pull request adds the Gift Card implementation for payment methods.

## Tested scenarios
<!-- Description of tested scenarios -->
* Giftcards:
  * Givex gift card
  * SVS gift card
  * ValueLink gift card
  * generic gift card

Card numbers as described on: https://docs.adyen.com/development-resources/test-cards/test-card-numbers#gift-cards

**Fixed issue**: #66   <!-- #-prefixed issue number -->

**Note**:
The Gift Card PIN can be optional.  
The field will only be shown in the UI, when the gift card detail property `encryptedSecurityCode.optional` is `false` (see below example). In all other cases if the field is not present or optional is true, the PIN field will be omitted.

```bash
# API: /paymentMethods
{
  ...
    "details": [
        {
            "key": "encryptedCardNumber",
            "type": "cardToken"
        },
        {
            "key": "encryptedSecurityCode",
            "optional": false,
            "type": "cardToken"
        },
       ...
    ],
    "name": "SVS",
    "supportsRecurring": true,
    "type": "svs"
}
``` 
