### PR TITLE
#70 add fallback when no shop is specified

### DIFF
--- a/Components/Configuration.php
+++ b/Components/Configuration.php
@@ -86,7 +86,7 @@ class Configuration
     public function getConfig($key = null, $shop = false)
     {
         if (!$shop) {
-            $shop = null;
+            $shop = Shopware()->Shop();
         }
 
         $config = $this->cachedConfigReader->getByPluginName(AdyenPayment::NAME, $shop);


### PR DESCRIPTION
## Summary
We added a fallback in case the shop is not set. When no shop is set when retrieving configuration the configuration of the current shop be returned.  

## Tested scenarios
Retrieve correct Merchant account when no shop is set.

**Fixed issue**:  #70 