### PR TITLE
AP-58 Enable Mobile bancontact payments

### DIFF
--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -186,7 +186,7 @@
 
         handlePaymentDataRedirectShopper: function (data) {
             const me = this;
-            if (['redirect', 'qrCode'].includes(data.action.type)) {
+            if ('redirect' === data.action.type || 'qrCode' === data.action.type) {
                 me.adyenCheckout
                     .createFromAction(data.action)
                     .mount(me.opts.mountRedirectSelector);

--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -114,6 +114,7 @@
                 case 'ChallengeShopper':
                     me.handlePaymentDataChallengeShopper(data);
                     break;
+                case 'Pending':
                 case 'RedirectShopper':
                     me.handlePaymentDataRedirectShopper(data);
                     break;
@@ -146,9 +147,9 @@
                             },
                         });
                     },
-                onError: function (error) {
-                    console.error(error);
-                }
+                    onError: function (error) {
+                        console.error(error);
+                    }
                 })
                 .mount('#AdyenIdentifyShopperThreeDS2');
         },
@@ -176,17 +177,19 @@
                             },
                         });
                     },
-                onError: function (error) {
-                    console.log(error);
-                }
+                    onError: function (error) {
+                        console.log(error);
+                    }
                 })
                 .mount('#AdyenChallengeShopperThreeDS2');
         },
 
         handlePaymentDataRedirectShopper: function (data) {
-            var me = this;
-            if (data.action.type === 'redirect') {
-                me.adyenCheckout.createFromAction(data.action).mount(me.opts.mountRedirectSelector);
+            const me = this;
+            if (['redirect', 'qrCode'].includes(data.action.type)) {
+                me.adyenCheckout
+                    .createFromAction(data.action)
+                    .mount(me.opts.mountRedirectSelector);
             }
         },
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Bancontact mobile payment option added, as per documentation, to the available payments.

## Tested scenarios

For the api v52 payment method:  bcmc_mobile_QR and bcmc_mobile_app are provided and passed to the Adyen checkout web component.
The code has also been verified to be able to work with api v64.

One issue arose: for bcmc_mobile_QR, 
On the test account for payment returned the response: `Could not find an acquirerAccount`.


**Fixed issue**: #58   <!-- #-prefixed issue number -->
