### PR TITLE
AP-73 alter notification url to /frontend/notification/adyen (default…

### DIFF
--- a/Controllers/Frontend/Notification.php
+++ b/Controllers/Frontend/Notification.php
@@ -22,11 +22,11 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
     private $incomingNotificationsManager;
 
     /**
-     * POST: /notification
+     * POST: /notification/adyen
      * @throws Enlight_Event_Exception
      * @throws AdyenException
      */
-    public function indexAction()
+    public function adyenAction()
     {
         if (!$this->checkAuthentication()) {
             $this->View()->assign('[Invalid or missing auth]');
@@ -109,7 +109,7 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
      */
     public function getWhitelistedCSRFActions()
     {
-        return ['index'];
+        return ['adyen'];
     }
 
     /**


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Rewrite of notification Url, original: `frontend/notification/index`
Due to restrictions of Shopware 5 and to not use seo url rewrite a basic url has been chosen: `notification/adyen`
Which follows default Shopware 5 route naming convention.

:warning: **Important**: this is a BC breaking change for the notification endpoint.  
Adyen account settings for `Server communication / Standard Notification` needs to be updated when upgrading.

## Tested scenarios
<!-- Description of tested scenarios -->
Test frontend url's: 
* https://yourshopname.com/frontend/notification/adyen
* https://yourshopname.com/notification/adyen

**Fixed issue**: #73 <!-- #-prefixed issue number -->
