### PR TITLE
[PW-3546] Adding payload and redirectResult GET parameters to transparent redirect

### DIFF
--- a/Controllers/Frontend/Transparent.php
+++ b/Controllers/Frontend/Transparent.php
@@ -7,8 +7,7 @@ use Shopware\Components\Logger;
 class Shopware_Controllers_Frontend_Transparent extends Shopware_Controllers_Frontend_Payment implements CSRFWhitelistAware
 {
 
-    const ALLOWED_PARAMS = ['MD', 'PaRes', 'payload', 'redirectResult'];
-
+    const ALLOWED_PARAMS = ['MD', 'PaRes'];
     /**
      * @var Logger
      */
@@ -45,13 +44,20 @@ class Shopware_Controllers_Frontend_Transparent extends Shopware_Controllers_Fro
 
     private function retrieveParams(): array
     {
-        $params = $this->Request()->getParams();
-        $result = array();
-        foreach (self::ALLOWED_PARAMS as $approvedKey) {
-            if (isset($params[$approvedKey])) {
-                $result[$approvedKey] = $params[$approvedKey];
+        $request = $this->Request();
+
+        //Getting all GET parameters except for Shopware's action, controller and module
+        $getParams = $request->getQuery();
+        unset($getParams['action'], $getParams['controller'], $getParams['module']);
+
+        //Filtering allowed POST parameters
+        $fullPostParams = $request->getParams();
+        $postParams = [];
+        foreach (self::ALLOWED_PARAMS as $allowedParam) {
+            if (isset($fullPostParams[$allowedParam])) {
+                $postParams[$allowedParam] = $fullPostParams[$allowedParam];
             }
         }
-        return $result;
+        return array_merge($getParams, $postParams);
     }
 }

--- a/Controllers/Frontend/Transparent.php
+++ b/Controllers/Frontend/Transparent.php
@@ -7,7 +7,7 @@ use Shopware\Components\Logger;
 class Shopware_Controllers_Frontend_Transparent extends Shopware_Controllers_Frontend_Payment implements CSRFWhitelistAware
 {
 
-    const ALLOWED_PARAMS = ['MD', 'PaRes', 'payload'];
+    const ALLOWED_PARAMS = ['MD', 'PaRes', 'payload', 'redirectResult'];
 
     /**
      * @var Logger

--- a/Controllers/Frontend/Transparent.php
+++ b/Controllers/Frontend/Transparent.php
@@ -7,6 +7,8 @@ use Shopware\Components\Logger;
 class Shopware_Controllers_Frontend_Transparent extends Shopware_Controllers_Frontend_Payment implements CSRFWhitelistAware
 {
 
+    const ALLOWED_PARAMS = ['MD', 'PaRes', 'payload'];
+
     /**
      * @var Logger
      */
@@ -29,30 +31,27 @@ class Shopware_Controllers_Frontend_Transparent extends Shopware_Controllers_Fro
      */
     public function redirectAction()
     {
-        $allowedPostParams = ['MD', 'PaRes'];
         $redirectUrl = Shopware()->Router()->assemble([
             'controller' => 'process',
             'action' => 'return',
         ]);
 
         $this->View()->assign('redirectUrl', $redirectUrl);
-        $this->View()->assign('postParams', $this->retrievePostParams($allowedPostParams));
+        $this->View()->assign('redirectParams', $this->retrieveParams());
         $this->logger->debug('Forward incoming POST response to process/return', [
-            'POST parameter keys' => $allowedPostParams
+            'POST and GET parameter keys' => self::ALLOWED_PARAMS
         ]);
     }
 
-    private function retrievePostParams(array $allowedParams): array
+    private function retrieveParams(): array
     {
-        $params = [];
-        foreach ($allowedParams as $key) {
-            if (null === $value = $this->Request()->getPost($key)) {
-                continue;
+        $params = $this->Request()->getParams();
+        $result = array();
+        foreach (self::ALLOWED_PARAMS as $approvedKey) {
+            if (isset($params[$approvedKey])) {
+                $result[$approvedKey] = $params[$approvedKey];
             }
-
-            $params[$key] = $value;
         }
-
-        return $params;
+        return $result;
     }
 }

--- a/Resources/views/frontend/transparent/redirect.tpl
+++ b/Resources/views/frontend/transparent/redirect.tpl
@@ -5,7 +5,7 @@
     <head><title></title></head>
     <body onload="document.forms['transparent_redirect'].submit();">
         <form id="transparent_redirect" method="POST" action="{$redirectUrl}">
-            {foreach $postParams as $value}
+            {foreach $redirectParams as $value}
                 <input type="hidden" name="{$value@key}" value="{$value|escape}" />
             {/foreach}
         </form>


### PR DESCRIPTION
## Summary
Paypal uses the GET parameter `payload` and Klarna uses `redirectResult`, here they are being added to the transparent redirect so they can be forwarded to the return controller.

## Tested scenarios
Paypal, Klarna and 3DS1 payments.

**Fixed issue**:  PW-3546, PW-3561
