### PR TITLE
[PW-3544] try/catch block for getting the Shop service from the backend

### DIFF
--- a/Components/Configuration.php
+++ b/Components/Configuration.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use AdyenPayment\AdyenPayment;
 use Shopware\Components\Plugin\CachedConfigReader;
 use Shopware\Models\Shop\Shop;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * Class Configuration
@@ -86,7 +87,12 @@ class Configuration
     public function getConfig($key = null, $shop = false)
     {
         if (!$shop) {
-            $shop = Shopware()->Shop();
+            try {
+                $shop = Shopware()->Shop();
+            } catch (ServiceNotFoundException $exception) {
+                //The Shop service is not available in the context (i.e. getting the config from the Backend)
+                $shop = null;
+            }
         }
 
         $config = $this->cachedConfigReader->getByPluginName(AdyenPayment::NAME, $shop);


### PR DESCRIPTION
## Summary
In some contexts (backend, cron, etc) there's no Shop service available. We're enclosing the service getter in a try/catch block so the Test API button in the backend uses the default null as Shop.

## Tested scenarios
Test button functions properly.
Frontend API calls use the Shop context.

**Fixed issue**:  PW-3544
