### PR TITLE
ASW-251 #84 bump Web Components to 3.12.1 highest compatible API v51

### DIFF
--- a/Resources/views/frontend/checkout/adyen_libaries.tpl
+++ b/Resources/views/frontend/checkout/adyen_libaries.tpl
@@ -2,12 +2,11 @@
     {if $sAdyenGoogleConfig}
         <script src="https://pay.google.com/gp/p/js/pay.js"></script>
     {/if}
-    <script src="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.8.1/adyen.js"
-            integrity="sha384-pLfJ6XKllmblOK86IVevGarh2cfeBr6lWAEkumlMA3hgTqKpEgNn8ID7zq4HsC6H"
+    <script src="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.12.1/adyen.js"
+            integrity="sha384-Z40LrT7R1YX9m5TJsqwQA5H3YqKvPA/DKBnPwXa4SwaDEs/feQSThsSph6PjbCQ1"
             crossorigin="anonymous"></script>
-
     <link rel="stylesheet"
-          href="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.8.1/adyen.css"
-          integrity="sha384-y1lKqffK5z+ENzddmGIfP3bcMRobxkjDt/9lyPAvV9H3JXbJYxCSD6L8TdyRMCGM"
-          crossorigin="anonymous">
+            href="https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.12.1/adyen.css"
+            integrity="sha384-GYuZ2hTudNw7WyFFpYgZ2+Dd1a1QqD0d0u7p6RE9F6q2yNnIEe6gPNs+Ml0QI5Mt"
+            crossorigin="anonymous">
 {/block}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Update the Web components library to a higher version compatible with Adyen API v51.
The issue occurs Adyen.js library conflicts with other js libraries used in Shopware.

The upgraded version should resolve these issue's, although it should be tested by the reporters as well to make sure.
Ideal web components should be upgrade to the latest version, but this needs to be implement after or during [#62 Upgrade Checkout API to v64]

## Tested scenarios
* Verify listed payments on checkout and web component interaction.
* Payment flow with credit card.

**Fixed issue**:  #84 
