### PR TITLE
Ap 103 second shop cannot decrypt api data

### DIFF
--- a/Components/Adyen/OriginKeysService.php
+++ b/Components/Adyen/OriginKeysService.php
@@ -14,9 +14,13 @@ use Shopware\Models\Shop\Shop;
 class OriginKeysService
 {
     /**
-     * @var CheckoutUtility
+     * @var ApiFactory
      */
-    private $checkoutUtility;
+    private $apiFactory;
+    /**
+     * @var ModelManager
+     */
+    private $models;
 
     /**
      * OriginKeysService constructor.
@@ -28,8 +32,8 @@ class OriginKeysService
         ApiFactory $apiFactory,
         ModelManager $models
     ) {
-        $mainShop = $models->getRepository(Shop::class)->findOneBy(['default' => 1]);
-        $this->checkoutUtility = new CheckoutUtility($apiFactory->create($mainShop));
+        $this->apiFactory = $apiFactory;
+        $this->models = $models;
     }
 
     /**
@@ -37,8 +41,12 @@ class OriginKeysService
      * @return mixed
      * @throws AdyenException
      */
-    public function generate(array $originDomains)
+    public function generate(array $originDomains, Shop $shop)
     {
-        return $this->checkoutUtility->originKeys(['originDomains' => $originDomains])['originKeys'];
+        $checkoutUtility = new CheckoutUtility(
+            $this->apiFactory->provide($shop)
+        );
+
+        return $checkoutUtility->originKeys(['originDomains' => $originDomains])['originKeys'];
     }
 }

--- a/Components/Adyen/PaymentMethodService.php
+++ b/Components/Adyen/PaymentMethodService.php
@@ -3,7 +3,6 @@
 namespace AdyenPayment\Components\Adyen;
 
 use Adyen\AdyenException;
-use Adyen\Client;
 use Adyen\Service\Checkout;
 use Adyen\Util\Currency;
 use AdyenPayment\Components\Configuration;
@@ -17,11 +16,6 @@ use Psr\Log\LoggerInterface;
 class PaymentMethodService
 {
     /**
-     * @var Client
-     */
-    private $apiClient;
-
-    /**
      * @var Configuration
      */
     private $configuration;
@@ -34,6 +28,10 @@ class PaymentMethodService
      * @var LoggerInterface
      */
     private $logger;
+    /**
+     * @var ApiFactory
+     */
+    private $apiFactory;
 
     /**
      * PaymentMethodService constructor.
@@ -46,7 +44,7 @@ class PaymentMethodService
         Configuration $configuration,
         LoggerInterface $logger
     ) {
-        $this->apiClient = $apiFactory->create();
+        $this->apiFactory = $apiFactory;
         $this->configuration = $configuration;
         $this->logger = $logger;
     }
@@ -72,7 +70,7 @@ class PaymentMethodService
             return $this->cache[$cacheKey];
         }
 
-        $checkout = new Checkout($this->apiClient);
+        $checkout = $this->getCheckout();
         $adyenCurrency = new Currency();
 
         $requestParams = [
@@ -116,11 +114,12 @@ class PaymentMethodService
     }
 
     /**
-     * @return Checkout
      * @throws AdyenException
      */
-    public function getCheckout()
+    public function getCheckout(): Checkout
     {
-        return new Checkout($this->apiClient);
+        $apiClient = $this->apiFactory->provide(Shopware()->Shop());
+
+        return new Checkout($apiClient);
     }
 }

--- a/Components/Adyen/RefundService.php
+++ b/Components/Adyen/RefundService.php
@@ -61,7 +61,7 @@ class RefundService
     {
         /** @var Order $order */
         $order = $this->modelManager->find(Order::class, $orderId);
-        $apiClient = $this->apiFactory->create($order->getShop());
+        $apiClient = $this->apiFactory->provide($order->getShop());
         $modification = new Modification($apiClient);
 
         /** @var PaymentInfo $paymentInfo */

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -24,7 +24,6 @@
             <argument type="service" id="adyen_payment.components.basket_service"/>
         </service>
         <service id="adyen_payment.components.adyen.apifactory" class="AdyenPayment\Components\Adyen\ApiFactory">
-            <argument type="service" id="models"/>
             <argument type="service" id="adyen_payment.components.configuration"/>
             <argument type="service" id="adyen_payment.logger"/>
         </service>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
All storefronts (=shops) of the same Shopware instance would use the main shop's API key 
and Merchant account for accessing Payments API.
Additionally also the Main shop credentials where used to configure the origin_key.

1. Codebase has been adjusted that each apiClient is constructed with their corresponding 
storefront API key and Merchant account (set in the plugin configuration).
1. Each storefront now stores their own generated origin_key (generation is done by Adyen CheckoutUtility).

## Tested scenarios
Setup:
* Adyen Account with multiple merchant accounts (named M1 & M2)
* Shopware instance with multiple storefronts (A & B)

Setup Shopware shop with multiple storefronts:
* Test storefront A, merchant M1: payment BCMC and 3DS :heavy_check_mark: 
* Test storefront A, merchant M1: with Credit Card (Mastercard) :heavy_check_mark: 
* Test storefront B, merchant M2: with BCMC and 3DS :heavy_check_mark: 
* Test storefront B, merchant M2 with Credit Card (Mastercard) :heavy_check_mark: 

Payment data can be decrypted by payments API, 
payments are registered to the correct merchant account.

**Fixed issue**: #103
