### PR TITLE
Store incoming notifications in new DB entity with no extra logic

### DIFF
--- a/AdyenPayment.php
+++ b/AdyenPayment.php
@@ -11,6 +11,7 @@ use AdyenPayment\Components\CompilerPass\NotificationProcessorCompilerPass;
 use AdyenPayment\Models\Notification;
 use AdyenPayment\Models\PaymentInfo;
 use AdyenPayment\Models\Refund;
+use AdyenPayment\Models\TextNotification;
 use Shopware\Bundle\AttributeBundle\Service\TypeMapping;
 use Shopware\Components\Logger;
 use Shopware\Components\Plugin;
@@ -216,6 +217,7 @@ class AdyenPayment extends Plugin
             $entityManager->getClassMetadata(Notification::class),
             $entityManager->getClassMetadata(PaymentInfo::class),
             $entityManager->getClassMetadata(Refund::class),
+            $entityManager->getClassMetadata(TextNotification::class)
         ];
     }
 

--- a/Components/FifoTextNotificationLoader.php
+++ b/Components/FifoTextNotificationLoader.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Components;
+
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+
+/**
+ * Class FifoNotificationLoader
+ * @package AdyenPayment\Components
+ */
+class FifoTextNotificationLoader
+{
+    /**
+     * @var TextNotificationManager
+     */
+    private $textNotificationManager;
+
+    /**
+     * FifoTextNotificationLoader constructor.
+     * @param TextNotificationManager $textNotificationManager
+     */
+    public function __construct(
+        TextNotificationManager $textNotificationManager
+    ) {
+        $this->textNotificationManager = $textNotificationManager;
+    }
+
+    public function get(): array
+    {
+        try {
+            return $this->textNotificationManager->getTextNextNotificationsToHandle();
+        } catch (NoResultException | NonUniqueResultException $e) {
+            return [];
+        }
+    }
+}

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -89,7 +89,6 @@ class IncomingNotificationManager
         foreach ($textNotificationItems as $textNotificationItem) {
             try {
                 if (!empty($textNotificationItem['NotificationRequestItem'])) {
-
                     if ($this->skipNotification($textNotificationItem['NotificationRequestItem'])) {
                         $this->logger->info('Skipped notification',
                             ['eventCode' => $notificationRequest['eventCode'] ?? '']);

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -90,8 +90,10 @@ class IncomingNotificationManager
             try {
                 if (!empty($textNotificationItem['NotificationRequestItem'])) {
                     if ($this->skipNotification($textNotificationItem['NotificationRequestItem'])) {
-                        $this->logger->info('Skipped notification',
-                            ['eventCode' => $notificationRequest['eventCode'] ?? '']);
+                        $this->logger->info(
+                            'Skipped notification',
+                            ['eventCode' => $notificationRequest['eventCode'] ?? '']
+                        );
                         continue;
                     }
 

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -86,7 +86,9 @@ class IncomingNotificationManager
             try {
                 if (!empty($textNotificationItem['NotificationRequestItem'])) {
                     $textNotification = new TextNotification();
-                    $textNotification->setTextNotification(json_encode($textNotificationItem['NotificationRequestItem']));
+                    $textNotification->setTextNotification(
+                        json_encode($textNotificationItem['NotificationRequestItem'])
+                    );
                     $this->entityManager->persist($textNotification);
                 }
             } catch (ORMException $exception) {

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -47,7 +47,6 @@ class IncomingNotificationManager
         $this->logger = $logger;
         $this->notificationBuilder = $notificationBuilder;
         $this->entityManager = $entityManager;
-        $this->notificationReceiver = $notificationReceiver;
     }
 
     /**
@@ -90,12 +89,12 @@ class IncomingNotificationManager
         foreach ($textNotificationItems as $textNotificationItem) {
             try {
                 if (!empty($textNotificationItem['NotificationRequestItem'])) {
-                  
-                    if ($this->skipNotification($notificationRequest)) {
+
+                    if ($this->skipNotification($textNotificationItem['NotificationRequestItem'])) {
                         $this->logger->info('Skipped notification', ['eventCode' => $notificationRequest['eventCode'] ?? '']);
                         continue;
                     }
-                  
+
                     $textNotification = new TextNotification();
                     $textNotification->setTextNotification(
                         json_encode($textNotificationItem['NotificationRequestItem'])

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -91,7 +91,8 @@ class IncomingNotificationManager
                 if (!empty($textNotificationItem['NotificationRequestItem'])) {
 
                     if ($this->skipNotification($textNotificationItem['NotificationRequestItem'])) {
-                        $this->logger->info('Skipped notification', ['eventCode' => $notificationRequest['eventCode'] ?? '']);
+                        $this->logger->info('Skipped notification',
+                            ['eventCode' => $notificationRequest['eventCode'] ?? '']);
                         continue;
                     }
 
@@ -111,10 +112,11 @@ class IncomingNotificationManager
 
     private function skipNotification(array $notificationRequest): bool
     {
-        if (strpos($notificationRequest['event_code'], 'REPORT_') !== false) {
-            return false;
+        if (!empty($notificationRequest['eventCode']) &&
+            strpos($notificationRequest['eventCode'], 'REPORT_') !== false) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -64,7 +64,11 @@ class IncomingNotificationManager
                     );
                     $this->entityManager->persist($notification);
                 }
-            } catch (InvalidParameterException | OrderNotFoundException $exception) {
+            } catch (InvalidParameterException $exception) {
+                $this->logger->warning(
+                    $exception->getMessage() . " " . $textNotificationItem->getTextNotification()
+                );
+            } catch (OrderNotFoundException $exception) {
                 $this->logger->warning(
                     $exception->getMessage() . " " . $textNotificationItem->getTextNotification()
                 );

--- a/Components/TextNotificationManager.php
+++ b/Components/TextNotificationManager.php
@@ -43,7 +43,7 @@ class TextNotificationManager
     public function getTextNextNotificationsToHandle(): array
     {
         $builder = $this->textNotificationRepository->createQueryBuilder('n');
-        $builder->orderBy('n.createdAt', 'ASC');
+        $builder->orderBy('n.createdAt', 'ASC')->setMaxResults(20);
 
         return $builder->getQuery()->getResult();
     }

--- a/Components/TextNotificationManager.php
+++ b/Components/TextNotificationManager.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Components;
+
+use AdyenPayment\Models\TextNotification;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityRepository;
+use Shopware\Components\Model\ModelManager;
+
+/**
+ * Class NotificationManager
+ * @package AdyenPayment\Components
+ */
+class TextNotificationManager
+{
+    /**
+     * @var ModelManager
+     */
+    private $modelManager;
+
+    /**
+     * @var ObjectRepository|EntityRepository
+     */
+    private $textNotificationRepository;
+
+
+    /**
+     * NotificationManager constructor.
+     * @param ModelManager $modelManager
+     */
+    public function __construct(
+        ModelManager $modelManager
+    ) {
+        $this->modelManager = $modelManager;
+        $this->textNotificationRepository = $modelManager->getRepository(TextNotification::class);
+    }
+
+    /**
+     * @return array
+     */
+    public function getTextNextNotificationsToHandle(): array
+    {
+        $builder = $this->textNotificationRepository->createQueryBuilder('n');
+        $builder->orderBy('n.createdAt', 'ASC');
+
+        return $builder->getQuery()->getResult();
+    }
+}

--- a/Controllers/Frontend/Notification.php
+++ b/Controllers/Frontend/Notification.php
@@ -40,7 +40,7 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
             return;
         }
 
-        if (!$this->saveNotifications($notifications)) {
+        if (!$this->saveTextNotification($notifications)) {
             $this->View()->assign('[notification save error]');
             return;
         }
@@ -94,14 +94,14 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
      * @return Generator
      * @throws Enlight_Event_Exception
      */
-    private function saveNotifications(array $notifications)
+    private function saveTextNotification(array $notifications)
     {
         $notifications = $this->events->filter(
             Event::NOTIFICATION_SAVE_FILTER_NOTIFICATIONS,
             $notifications
         );
 
-        return iterator_count($this->incomingNotificationsManager->save($notifications)) === 0;
+        return iterator_count($this->incomingNotificationsManager->saveTextNotification($notifications)) === 0;
     }
 
     /**

--- a/Controllers/Frontend/Notification.php
+++ b/Controllers/Frontend/Notification.php
@@ -62,7 +62,6 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
         try {
             $notifications = $this->getNotificationItems();
             $this->authorizationValidator->validate($notifications);
-
         } catch (AuthorizationException $exception) {
             $this->View()->assign('responseData', NotificationResponseFactory::unauthorized($exception->getMessage()));
 

--- a/Controllers/Frontend/Notification.php
+++ b/Controllers/Frontend/Notification.php
@@ -63,7 +63,6 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
             $notifications = $this->getNotificationItems();
             $this->authorizationValidator->validate($notifications);
 
-            $this->saveNotifications($notifications);
         } catch (AuthorizationException $exception) {
             $this->View()->assign('responseData', NotificationResponseFactory::unauthorized($exception->getMessage()));
 
@@ -79,7 +78,7 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
             $this->View()->assign('[notification save error]');
             return;
         }
-      
+
         // on valid credentials, always return ACCEPTED
         $this->View()->assign('responseData', NotificationResponseFactory::accepted());
     }

--- a/Models/Feedback/TextNotificationItemFeedback.php
+++ b/Models/Feedback/TextNotificationItemFeedback.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AdyenPayment\Models\Feedback;
+
+/**
+ * Class TextNotificationItemFeedback
+ * @package AdyenPayment\Models\Feedback
+ */
+class TextNotificationItemFeedback
+{
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var array
+     */
+    private $textNotificationItem;
+
+    /**
+     * TextNotificationItemFeedback constructor.
+     * @param string $message
+     * @param array $textNotificationItem
+     */
+    public function __construct(
+        string $message,
+        array $textNotificationItem
+    ) {
+        $this->message = $message;
+        $this->textNotificationItem = $textNotificationItem;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     * @return TextNotificationItemFeedback
+     */
+    public function setMessage(string $message): TextNotificationItemFeedback
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTextNotificationItem(): array
+    {
+        return $this->textNotificationItem;
+    }
+
+    /**
+     * @param array $textNotificationItem
+     * @return TextNotificationItemFeedback
+     */
+    public function setTextNotificationItem(array $textNotificationItem): TextNotificationItemFeedback
+    {
+        $this->textNotificationItem = $textNotificationItem;
+        return $this;
+    }
+}

--- a/Models/TextNotification.php
+++ b/Models/TextNotification.php
@@ -33,18 +33,11 @@ class TextNotification extends ModelEntity implements \JsonSerializable
     private $createdAt;
 
     /**
-     * @var \DateTime
-     * @ORM\Column(name="updated_at", type="datetime")
-     */
-    private $updatedAt;
-
-    /**
      * TextNotification constructor
      */
     public function __construct()
     {
         $this->setCreatedAt(new \DateTime('now'));
-        $this->setUpdatedAt(new \DateTime('now'));
     }
 
     /**
@@ -102,24 +95,6 @@ class TextNotification extends ModelEntity implements \JsonSerializable
     }
 
     /**
-     * @return \DateTime
-     */
-    public function getUpdatedAt(): \DateTime
-    {
-        return $this->updatedAt;
-    }
-
-    /**
-     * @param \DateTime $updatedAt
-     * @return TextNotification
-     */
-    public function setUpdatedAt(\DateTime $updatedAt): TextNotification
-    {
-        $this->updatedAt = $updatedAt;
-        return $this;
-    }
-
-    /**
      * Specify data which should be serialized to JSON
      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
      * @return mixed data which can be serialized by <b>json_encode</b>,
@@ -131,8 +106,7 @@ class TextNotification extends ModelEntity implements \JsonSerializable
         return [
             'id' => $this->getId(),
             'textNotification' => $this->getTextNotification(),
-            'createdAt' => $this->getCreatedAt(),
-            'updatedAt' => $this->getUpdatedAt()
+            'createdAt' => $this->getCreatedAt()
         ];
     }
 }

--- a/Models/TextNotification.php
+++ b/Models/TextNotification.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace AdyenPayment\Models;
+
+use Doctrine\ORM\Mapping as ORM;
+use Shopware\Components\Model\ModelEntity;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="s_plugin_adyen_text_notification")
+ */
+class TextNotification extends ModelEntity implements \JsonSerializable
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+
+    /**
+     * @var string
+     * @ORM\Column(name="text_notification", type="text")
+     */
+    private $textNotification;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(name="updated_at", type="datetime")
+     */
+    private $updatedAt;
+
+    /**
+     * TextNotification constructor
+     */
+    public function __construct()
+    {
+        $this->setCreatedAt(new \DateTime('now'));
+        $this->setUpdatedAt(new \DateTime('now'));
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return TextNotification
+     */
+    public function setId(int $id): TextNotification
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTextNotification(): string
+    {
+        return $this->textNotification;
+    }
+
+    /**
+     * @param string $textNotification
+     * @return TextNotification
+     */
+    public function setTextNotification(string $textNotification): TextNotification
+    {
+        $this->textNotification = $textNotification;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param \DateTime $createdAt
+     * @return TextNotification
+     */
+    public function setCreatedAt(\DateTime $createdAt): TextNotification
+    {
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdatedAt(): \DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param \DateTime $updatedAt
+     * @return TextNotification
+     */
+    public function setUpdatedAt(\DateTime $updatedAt): TextNotification
+    {
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->getId(),
+            'textNotification' => $this->getTextNotification(),
+            'createdAt' => $this->getCreatedAt(),
+            'updatedAt' => $this->getUpdatedAt()
+        ];
+    }
+}

--- a/Resources/services/adyen.xml
+++ b/Resources/services/adyen.xml
@@ -3,9 +3,6 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Adyen\Util\HmacSignature" />
-        <service id="Adyen\Service\NotificationReceiver">
-            <argument type="service" id="Adyen\Util\HmacSignature" />
-        </service>
     </services>
 </container>
 

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -47,6 +47,10 @@
                  class="AdyenPayment\Components\FifoNotificationLoader">
             <argument type="service" id="adyen_payment.components.notification_manager"/>
         </service>
+        <service id="adyen_payment.components.fifo_text_notification_loader"
+                 class="AdyenPayment\Components\FifoTextNotificationLoader">
+            <argument type="service" id="adyen_payment.components.text_notification_manager"/>
+        </service>
         <service id="adyen_payment.components.payment_status_update" class="AdyenPayment\Components\PaymentStatusUpdate">
             <argument type="service" id="models"/>
             <argument type="service" id="events"/>

--- a/Resources/services/cronjobs.xml
+++ b/Resources/services/cronjobs.xml
@@ -7,7 +7,9 @@
         <service id="adyen_payment.subscriber.cronjob.process_notifications" class="AdyenPayment\Subscriber\Cronjob\ProcessNotifications">
             <tag name="shopware.event_subscriber"/>
             <argument type="service" id="adyen_payment.components.fifo_notification_loader"/>
+            <argument type="service" id="adyen_payment.components.fifo_text_notification_loader"/>
             <argument type="service" id="adyen_payment.components.notification_processor"/>
+            <argument type="service" id="adyen_payment.components.incoming_notification_manager"/>
             <argument type="service" id="adyen_payment.logger.notifications" />
         </service>
     </services>

--- a/Resources/services/managers.xml
+++ b/Resources/services/managers.xml
@@ -11,6 +11,10 @@
                  class="AdyenPayment\Components\NotificationManager">
             <argument type="service" id="models"/>
         </service>
+        <service id="adyen_payment.components.text_notification_manager"
+                 class="AdyenPayment\Components\TextNotificationManager">
+            <argument type="service" id="models"/>
+        </service>
         <service id="adyen_payment.components.incoming_notification_manager"
                  class="AdyenPayment\Components\IncomingNotificationManager">
             <argument type="service" id="adyen_payment.logger.notifications"/>

--- a/Resources/services/managers.xml
+++ b/Resources/services/managers.xml
@@ -20,7 +20,6 @@
             <argument type="service" id="adyen_payment.logger.notifications"/>
             <argument type="service" id="adyen_payment.components.builder.notification_builder"/>
             <argument type="service" id="models"/>
-            <argument type="service" id="Adyen\Service\NotificationReceiver" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
## Summary
When notifications are received ideally no extra logic is done other than storing them in the database after the authentication methods have been verified. With this PR we're saving the incoming notifications AS IS in a new database entity. On cron job run they are converted and stored as a regular notification to be processed.

## Tested scenarios
After the authentication is valid incoming notifications are received successfully regardless of content, and stored in a new table `s_plugin_adyen_text_notification`.
On cron job run the text notifications stored are fetched, converted into regular notifications in `s_plugin_adyen_order_notification` and processed.

**Fixed issue**: #81 