### PR TITLE
Ap 257 notifcations reponse

### DIFF
--- a/Controllers/Frontend/Notification.php
+++ b/Controllers/Frontend/Notification.php
@@ -4,7 +4,10 @@ use Adyen\AdyenException;
 use Adyen\Util\HmacSignature;
 use AdyenPayment\Components\Configuration;
 use AdyenPayment\Components\IncomingNotificationManager;
+use AdyenPayment\Exceptions\InvalidAuthenticationException;
+use AdyenPayment\Exceptions\InvalidHmacException;
 use AdyenPayment\Models\Event;
+use Psr\Log\LoggerInterface;
 use Shopware\Components\ContainerAwareEventManager;
 use Shopware\Components\CSRFWhitelistAware;
 
@@ -15,102 +18,18 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
      * @var ContainerAwareEventManager
      */
     private $events;
-
     /**
      * @var IncomingNotificationManager
      */
     private $incomingNotificationsManager;
-
     /**
-     * POST: /notification/adyen
-     * @throws Enlight_Event_Exception
-     * @throws AdyenException
+     * @var Configuration
      */
-    public function adyenAction()
-    {
-        if (!$this->checkAuthentication()) {
-            $this->View()->assign('[Invalid or missing auth]');
-            return;
-        }
-
-        $notifications = $this->getNotificationItems();
-
-        if (!$this->checkHMAC($notifications)) {
-            $this->View()->assign('[wrong hmac detected]');
-            return;
-        }
-
-        if (!$this->saveNotifications($notifications)) {
-            $this->View()->assign('[notification save error]');
-            return;
-        }
-
-        $this->View()->assign('[accepted]');
-    }
-
+    private $configuration;
     /**
-     * @return mixed
-     * @throws Enlight_Event_Exception
+     * @var LoggerInterface
      */
-    private function getNotificationItems()
-    {
-        $jsonbody = json_decode($this->Request()->getRawBody(), true);
-        $notificationItems = $jsonbody['notificationItems'];
-
-        $this->events->notify(
-            Event::NOTIFICATION_RECEIVE,
-            [
-                'items' => $notificationItems
-            ]
-        );
-
-        return $notificationItems;
-    }
-
-    /**
-     * @param $notifications
-     * @return bool
-     * @throws AdyenException
-     */
-    private function checkHMAC($notifications)
-    {
-        /** @var Configuration $configuration */
-        $configuration = $this->get('adyen_payment.components.configuration');
-        $adyenUtils = new HmacSignature();
-
-        foreach ($notifications as $notificationItem) {
-            $params = $notificationItem['NotificationRequestItem'];
-            $hmacCheck = $adyenUtils->isValidNotificationHMAC($configuration->getNotificationHmac(), $params);
-            if (!$hmacCheck) {
-                $this->get('adyen_payment.logger.notifications')->notice('Invalid HMAC detected');
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param array $notifications
-     * @return Generator
-     * @throws Enlight_Event_Exception
-     */
-    private function saveNotifications(array $notifications)
-    {
-        $notifications = $this->events->filter(
-            Event::NOTIFICATION_SAVE_FILTER_NOTIFICATIONS,
-            $notifications
-        );
-
-        return iterator_count($this->incomingNotificationsManager->save($notifications)) === 0;
-    }
-
-    /**
-     * Whitelist notifyAction
-     */
-    public function getWhitelistedCSRFActions()
-    {
-        return ['adyen'];
-    }
+    private $logger;
 
     /**
      * @throws Exception
@@ -120,6 +39,8 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();
         $this->events = $this->get('events');
         $this->incomingNotificationsManager = $this->get('adyen_payment.components.incoming_notification_manager');
+        $this->configuration = $this->get('adyen_payment.components.configuration');
+        $this->logger = $this->get('adyen_payment.logger.notifications');
     }
 
     public function postDispatch()
@@ -143,23 +64,121 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
         $this->Response()->setBody($data);
     }
 
+    /**
+     * POST: /notification/adyen
+     */
+    public function adyenAction()
+    {
+        try {
+            $this->checkAuthentication();
+            $notifications = $this->getNotificationItems();
+            $this->checkHMAC($notifications);
+
+            $this->saveNotifications($notifications);
+        } catch (InvalidAuthenticationException $exception) {
+            $this->logger->critical($exception->getMessage(), [
+                'trace' => $exception->getTraceAsString(),
+                'previous' => $exception->getPrevious()
+            ]);
+            $this->View()->assign('[Invalid or missing auth]');
+
+            return;
+        } catch (InvalidHmacException $exception) {
+            $this->logger->critical($exception->getMessage(), [
+                'trace' => $exception->getTraceAsString(),
+                'previous' => $exception->getPrevious()
+            ]);
+            $this->View()->assign('[wrong hmac detected]');
+
+            return;
+        } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage(), [
+                'trace' => $exception->getTraceAsString(),
+                'previous' => $exception->getPrevious()
+            ]);
+        }
+
+        // on valid credentials, always return ACCEPTED
+        $this->View()->assign('[accepted]');
+    }
+
+    /**
+     * Whitelist notifyAction
+     */
+    public function getWhitelistedCSRFActions()
+    {
+        return ['adyen'];
+    }
+
+    /**
+     * @return array|mixed
+     * @throws Enlight_Event_Exception
+     */
+    private function getNotificationItems()
+    {
+        $jsonbody = json_decode($this->Request()->getRawBody(), true);
+        $notificationItems = $jsonbody['notificationItems'] ?? [];
+        if (!$notificationItems) {
+            return [];
+        }
+
+        $this->events->notify(
+            Event::NOTIFICATION_RECEIVE,
+            [
+                'items' => $notificationItems
+            ]
+        );
+
+        return $notificationItems;
+    }
+
+    /**
+     * @param $notifications
+     */
+    private function checkHMAC(array $notifications)
+    {
+        $adyenUtils = new HmacSignature();
+        foreach ($notifications as $notificationItem) {
+            $params = $notificationItem['NotificationRequestItem'];
+            try {
+                $hmacCheck = $adyenUtils->isValidNotificationHMAC($this->configuration->getNotificationHmac(), $params);
+                if (!$hmacCheck) {
+                    throw InvalidHmacException::withHmacKey($params["additionalData"]["hmacSignature"] ?? '');
+                }
+            } catch (AdyenException $exception) {
+                throw InvalidHmacException::fromAdyenException($exception);
+            }
+        }
+    }
+
+    /**
+     * @param array $notifications
+     * @return Generator
+     * @throws Enlight_Event_Exception
+     */
+    private function saveNotifications(array $notifications)
+    {
+        $notifications = $this->events->filter(
+            Event::NOTIFICATION_SAVE_FILTER_NOTIFICATIONS,
+            $notifications
+        );
+
+        return iterator_count($this->incomingNotificationsManager->save($notifications)) === 0;
+    }
+
+    /**
+     * @throws InvalidAuthenticationException
+     */
     private function checkAuthentication()
     {
-        /** @var Configuration $configuration */
-        $configuration = $this->get('adyen_payment.components.configuration');
-
         if (!isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
-            return false;
+            throw InvalidAuthenticationException::missingAuthentication();
         }
-
         $authUsername = $_SERVER['PHP_AUTH_USER'];
         $authPassword = $_SERVER['PHP_AUTH_PW'];
-
-        if ($authUsername !== $configuration->getNotificationAuthUsername() ||
-            $authPassword !== $configuration->getNotificationAuthPassword()) {
-            return false;
+        if ($authUsername !== $this->configuration->getNotificationAuthUsername() ||
+            $authPassword !== $this->configuration->getNotificationAuthPassword()) {
+            throw InvalidAuthenticationException::invalidCredentials();
         }
-
-        return true;
     }
 }

--- a/Controllers/Frontend/Notification.php
+++ b/Controllers/Frontend/Notification.php
@@ -1,15 +1,14 @@
 <?php
 
-use Adyen\AdyenException;
-use Adyen\Util\HmacSignature;
-use AdyenPayment\Components\Configuration;
 use AdyenPayment\Components\IncomingNotificationManager;
-use AdyenPayment\Exceptions\InvalidAuthenticationException;
-use AdyenPayment\Exceptions\InvalidHmacException;
+use AdyenPayment\Exceptions\AuthorizationException;
+use AdyenPayment\Http\Response\NotificationResponseFactory;
+use AdyenPayment\Http\Validator\Notification\NotificationValidatorInterface;
 use AdyenPayment\Models\Event;
 use Psr\Log\LoggerInterface;
 use Shopware\Components\ContainerAwareEventManager;
 use Shopware\Components\CSRFWhitelistAware;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 //phpcs:ignore PSR1.Classes.ClassDeclaration.MissingNamespace, Squiz.Classes.ValidClassName.NotCamelCaps, Generic.Files.LineLength.TooLong
 class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Frontend_Payment implements CSRFWhitelistAware
@@ -23,13 +22,13 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
      */
     private $incomingNotificationsManager;
     /**
-     * @var Configuration
-     */
-    private $configuration;
-    /**
      * @var LoggerInterface
      */
     private $logger;
+    /**
+     * @var NotificationValidatorInterface
+     */
+    private $authorizationValidator;
 
     /**
      * @throws Exception
@@ -39,29 +38,20 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();
         $this->events = $this->get('events');
         $this->incomingNotificationsManager = $this->get('adyen_payment.components.incoming_notification_manager');
-        $this->configuration = $this->get('adyen_payment.components.configuration');
         $this->logger = $this->get('adyen_payment.logger.notifications');
+        $this->authorizationValidator = $this->get('AdyenPayment\Http\Validator\Notification\AuthorizationValidator');
     }
 
     public function postDispatch()
     {
         $data = $this->View()->getAssign();
-        $pretty = $this->Request()->getParam('pretty', false);
-
-        array_walk_recursive($data, static function (&$value) {
-            // Convert DateTime instances to ISO-8601 Strings
-            if ($value instanceof DateTime) {
-                $value = $value->format(DateTime::ISO8601);
-            }
-        });
-
-        $data = Zend_Json::encode($data);
-        if ($pretty) {
-            $data = Zend_Json::prettyPrint($data);
+        $response = $data['responseData'] ?? null;
+        if (!$response instanceof JsonResponse) {
+            $response = NotificationResponseFactory::fromShopwareResponse($this->Request(), $data);
         }
-
-        $this->Response()->setHeader('content-type', 'application/json', true);
-        $this->Response()->setBody($data);
+        $this->Response()->setHeader('Content-type', $response->headers->get('Content-Type'), true);
+        $this->Response()->setHttpResponseCode($response->getStatusCode());
+        $this->Response()->setBody($response->getContent());
     }
 
     /**
@@ -70,36 +60,23 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
     public function adyenAction()
     {
         try {
-            $this->checkAuthentication();
             $notifications = $this->getNotificationItems();
-            $this->checkHMAC($notifications);
+            $this->authorizationValidator->validate($notifications);
 
             $this->saveNotifications($notifications);
-        } catch (InvalidAuthenticationException $exception) {
-            $this->logger->critical($exception->getMessage(), [
-                'trace' => $exception->getTraceAsString(),
-                'previous' => $exception->getPrevious()
-            ]);
-            $this->View()->assign('[Invalid or missing auth]');
-
-            return;
-        } catch (InvalidHmacException $exception) {
-            $this->logger->critical($exception->getMessage(), [
-                'trace' => $exception->getTraceAsString(),
-                'previous' => $exception->getPrevious()
-            ]);
-            $this->View()->assign('[wrong hmac detected]');
+        } catch (AuthorizationException $exception) {
+            $this->View()->assign('responseData', NotificationResponseFactory::unauthorized($exception->getMessage()));
 
             return;
         } catch (\Exception $exception) {
             $this->logger->error($exception->getMessage(), [
                 'trace' => $exception->getTraceAsString(),
-                'previous' => $exception->getPrevious()
+                'previous' => $exception->getPrevious(),
             ]);
         }
 
         // on valid credentials, always return ACCEPTED
-        $this->View()->assign('[accepted]');
+        $this->View()->assign('responseData', NotificationResponseFactory::accepted());
     }
 
     /**
@@ -125,30 +102,11 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
         $this->events->notify(
             Event::NOTIFICATION_RECEIVE,
             [
-                'items' => $notificationItems
+                'items' => $notificationItems,
             ]
         );
 
         return $notificationItems;
-    }
-
-    /**
-     * @param $notifications
-     */
-    private function checkHMAC(array $notifications)
-    {
-        $adyenUtils = new HmacSignature();
-        foreach ($notifications as $notificationItem) {
-            $params = $notificationItem['NotificationRequestItem'];
-            try {
-                $hmacCheck = $adyenUtils->isValidNotificationHMAC($this->configuration->getNotificationHmac(), $params);
-                if (!$hmacCheck) {
-                    throw InvalidHmacException::withHmacKey($params["additionalData"]["hmacSignature"] ?? '');
-                }
-            } catch (AdyenException $exception) {
-                throw InvalidHmacException::fromAdyenException($exception);
-            }
-        }
     }
 
     /**
@@ -164,21 +122,5 @@ class Shopware_Controllers_Frontend_Notification extends Shopware_Controllers_Fr
         );
 
         return iterator_count($this->incomingNotificationsManager->save($notifications)) === 0;
-    }
-
-    /**
-     * @throws InvalidAuthenticationException
-     */
-    private function checkAuthentication()
-    {
-        if (!isset($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
-            throw InvalidAuthenticationException::missingAuthentication();
-        }
-        $authUsername = $_SERVER['PHP_AUTH_USER'];
-        $authPassword = $_SERVER['PHP_AUTH_PW'];
-        if ($authUsername !== $this->configuration->getNotificationAuthUsername() ||
-            $authPassword !== $this->configuration->getNotificationAuthPassword()) {
-            throw InvalidAuthenticationException::invalidCredentials();
-        }
     }
 }

--- a/Exceptions/AuthorizationException.php
+++ b/Exceptions/AuthorizationException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Exceptions;
+
+abstract class AuthorizationException extends \InvalidArgumentException
+{
+}

--- a/Exceptions/InvalidAuthenticationException.php
+++ b/Exceptions/InvalidAuthenticationException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Exceptions;
+
+class InvalidAuthenticationException extends \InvalidArgumentException
+{
+    public static function missingAuthentication(): self
+    {
+        return new self('Missing notification authentication credentials');
+    }
+
+    public static function invalidCredentials(): self
+    {
+        return new self('Invalid notification authentication credentials');
+    }
+}

--- a/Exceptions/InvalidAuthenticationException.php
+++ b/Exceptions/InvalidAuthenticationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AdyenPayment\Exceptions;
 
-class InvalidAuthenticationException extends \InvalidArgumentException
+class InvalidAuthenticationException extends AuthorizationException
 {
     public static function missingAuthentication(): self
     {

--- a/Exceptions/InvalidHmacException.php
+++ b/Exceptions/InvalidHmacException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Exceptions;
+
+use Adyen\AdyenException;
+
+class InvalidHmacException extends \InvalidArgumentException
+{
+    public static function withHmacKey(string $hmac): self
+    {
+        return new self('Invalid notification HMAC detected "'.$hmac.'"');
+    }
+
+    public static function fromAdyenException(AdyenException $exception): self
+    {
+        return new self($exception->getMessage(), $exception->getCode(), $exception);
+    }
+}

--- a/Exceptions/InvalidHmacException.php
+++ b/Exceptions/InvalidHmacException.php
@@ -6,7 +6,7 @@ namespace AdyenPayment\Exceptions;
 
 use Adyen\AdyenException;
 
-class InvalidHmacException extends \InvalidArgumentException
+class InvalidHmacException extends AuthorizationException
 {
     public static function withHmacKey(string $hmac): self
     {

--- a/Http/Response/NotificationResponseFactory.php
+++ b/Http/Response/NotificationResponseFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Http\Response;
+
+use Enlight_Controller_Request_RequestHttp;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Zend_Json;
+
+class NotificationResponseFactory
+{
+    public static function accepted(): JsonResponse
+    {
+        return new JsonResponse('[accepted]', Response::HTTP_ACCEPTED);
+    }
+
+    public static function unauthorized(string $message): JsonResponse
+    {
+        return new JsonResponse([
+            'success' => false,
+            'message' => $message,
+        ], Response::HTTP_UNAUTHORIZED);
+    }
+
+    public static function fromShopwareResponse(Enlight_Controller_Request_RequestHttp $request, $data): JsonResponse
+    {
+        $pretty = (bool)$request->getParam('pretty', false);
+        if (true === $pretty) {
+            return new JsonResponse(Zend_Json::prettyPrint($data));
+        }
+
+        return new JsonResponse(Zend_Json::encode(array_map(function ($value) {
+            return $value instanceof \DateTimeInterface ? $value->format(\DateTimeInterface::ISO8601) : $value;
+        }, $data)));
+    }
+}

--- a/Http/Validator/Notification/AuthenticationValidator.php
+++ b/Http/Validator/Notification/AuthenticationValidator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Http\Validator\Notification;
+
+use AdyenPayment\Components\Configuration;
+use AdyenPayment\Exceptions\InvalidAuthenticationException;
+
+class AuthenticationValidator implements NotificationValidatorInterface
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @throws InvalidAuthenticationException
+     */
+    public function validate(array $notifications)
+    {
+        $authUsername = $_SERVER['PHP_AUTH_USER'] ?? '';
+        $authPassword = $_SERVER['PHP_AUTH_PW'] ?? '';
+
+        if (!$authUsername || !$authPassword) {
+            throw InvalidAuthenticationException::missingAuthentication();
+        }
+
+        if ($this->configuration->getNotificationAuthUsername() !== $authUsername
+            || $this->configuration->getNotificationAuthPassword() !== $authPassword
+        ) {
+            throw InvalidAuthenticationException::invalidCredentials();
+        }
+    }
+}

--- a/Http/Validator/Notification/Chain.php
+++ b/Http/Validator/Notification/Chain.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Http\Validator\Notification;
+
+class Chain implements NotificationValidatorInterface
+{
+    /**
+     * @var NotificationValidatorInterface[]
+     */
+    private $validators;
+
+    public function __construct(NotificationValidatorInterface ...$validators)
+    {
+        $this->validators = $validators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate(array $notifications)
+    {
+        foreach ($this->validators as $validator) {
+            $validator->validate($notifications);
+        }
+    }
+}

--- a/Http/Validator/Notification/HmacValidator.php
+++ b/Http/Validator/Notification/HmacValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Http\Validator\Notification;
+
+use Adyen\AdyenException;
+use Adyen\Util\HmacSignature;
+use AdyenPayment\Components\Configuration;
+use AdyenPayment\Exceptions\InvalidHmacException;
+
+class HmacValidator implements NotificationValidatorInterface
+{
+    /**
+     * @var HmacSignature
+     */
+    private $hmacSignatureService;
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    public function __construct(HmacSignature $hmacSignatureService, Configuration $configuration)
+    {
+        $this->hmacSignatureService = $hmacSignatureService;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @throws InvalidHmacException
+     */
+    public function validate(array $notifications)
+    {
+        foreach ($notifications as $notificationItem) {
+            try {
+                $params = $notificationItem['NotificationRequestItem'] ?? [];
+                $hmacCheck = $this->hmacSignatureService->isValidNotificationHMAC(
+                    $this->configuration->getNotificationHmac(),
+                    $params
+                );
+                if (!$hmacCheck) {
+                    throw InvalidHmacException::withHmacKey($params["additionalData"]["hmacSignature"] ?? '');
+                }
+            } catch (AdyenException $exception) {
+                throw InvalidHmacException::fromAdyenException($exception);
+            }
+        }
+    }
+}

--- a/Http/Validator/Notification/LoggingAuthorizationValidatorDecorator.php
+++ b/Http/Validator/Notification/LoggingAuthorizationValidatorDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Http\Validator\Notification;
+
+use AdyenPayment\Exceptions\AuthorizationException;
+use Psr\Log\LoggerInterface;
+
+class LoggingAuthorizationValidatorDecorator implements NotificationValidatorInterface
+{
+    /**
+     * @var NotificationValidatorInterface
+     */
+    private $authorizationValidator;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(NotificationValidatorInterface $authenticationValidator, LoggerInterface $logger)
+    {
+        $this->authorizationValidator = $authenticationValidator;
+        $this->logger = $logger;
+    }
+
+    public function validate(array $notifications)
+    {
+        try {
+            $this->authorizationValidator->validate($notifications);
+        } catch (AuthorizationException $exception) {
+            $this->logger->critical($exception->getMessage(), [
+                'trace' => $exception->getTraceAsString(),
+                'previous' => $exception->getPrevious(),
+            ]);
+
+            throw $exception;
+        }
+    }
+}

--- a/Http/Validator/Notification/NotificationValidatorInterface.php
+++ b/Http/Validator/Notification/NotificationValidatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Http\Validator\Notification;
+
+use AdyenPayment\Exceptions\AuthorizationException;
+
+interface NotificationValidatorInterface
+{
+    /**
+     * @throws AuthorizationException and derived exceptions
+     */
+    public function validate(array $notifications);
+}

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -9,5 +9,6 @@
         <import resource="services/managers.xml"/>
         <import resource="services/subscribers.xml"/>
         <import resource="services/cronjobs.xml"/>
+        <import resource="services/adyen.xml"/>
     </imports>
 </container>

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -10,5 +10,6 @@
         <import resource="services/subscribers.xml"/>
         <import resource="services/cronjobs.xml"/>
         <import resource="services/adyen.xml"/>
+        <import resource="services/validators.xml"/>
     </imports>
 </container>

--- a/Resources/services/adyen.xml
+++ b/Resources/services/adyen.xml
@@ -1,0 +1,11 @@
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Adyen\Util\HmacSignature" />
+        <service id="Adyen\Service\NotificationReceiver">
+            <argument type="service" id="Adyen\Util\HmacSignature" />
+        </service>
+    </services>
+</container>
+

--- a/Resources/services/managers.xml
+++ b/Resources/services/managers.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="adyen_payment.logger.notifications"/>
             <argument type="service" id="adyen_payment.components.builder.notification_builder"/>
             <argument type="service" id="models"/>
+            <argument type="service" id="Adyen\Service\NotificationReceiver" />
         </service>
     </services>
 </container>

--- a/Resources/services/validators.xml
+++ b/Resources/services/validators.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- Chains -->
+        <service id="AdyenPayment\Http\Validator\Notification\AuthorizationValidator"
+                 class="AdyenPayment\Http\Validator\Notification\Chain">
+            <argument type="service" id="AdyenPayment\Http\Validator\Notification\AuthenticationValidator"/>
+            <argument type="service" id="AdyenPayment\Http\Validator\Notification\HmacValidator"/>
+        </service>
+        <service id="AdyenPayment\Http\Validator\Notification\LoggingAuthorizationValidatorDecorator"
+                 decorates="AdyenPayment\Http\Validator\Notification\AuthorizationValidator">
+            <argument type="service"
+                      id="AdyenPayment\Http\Validator\Notification\LoggingAuthorizationValidatorDecorator.inner"/>
+            <argument type="service" id="adyen_payment.logger.notifications"/>
+        </service>
+
+        <!-- Validators -->
+        <service id="AdyenPayment\Http\Validator\Notification\AuthenticationValidator">
+            <argument type="service" id="adyen_payment.components.configuration" />
+        </service>
+        <service id="AdyenPayment\Http\Validator\Notification\HmacValidator">
+            <argument type="service" id="Adyen\Util\HmacSignature" />
+            <argument type="service" id="adyen_payment.components.configuration" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
**Responses on incoming notification:**
  * process Authentication, on failure return failed message (HTTP 401)
  * process HmacKey, on failure return failed message (HTTP 401)
  * all other notifications sent response '[accepted]' (HTTP 202)
  * use unified way to create JsonResponse with status code (aligned responses with docs and SW 6 Plugin)
  * refactor Validation to chained validation

**Processing notification:**
  * skip report notification

## Tested scenarios

Test cases:
* Missing Authentication exception handling
* Invalid Authentication exception handling
* Missing Hmac key exception handling
* Invalid Hmac key exception handling
* Skip Report notification

**Fixed issue**:  #111 <!-- #-prefixed issue number -->
