### PR TITLE
Ap 256 payment data missing

### DIFF
--- a/AdyenPayment.php
+++ b/AdyenPayment.php
@@ -36,7 +36,6 @@ class AdyenPayment extends Plugin
 
     const SESSION_ADYEN_PAYMENT = 'adyenPayment';
     const SESSION_ADYEN_PAYMENT_VALID = 'adyenPaymentValid';
-    const SESSION_ADYEN_PAYMENT_DATA = 'adyenPaymentData';
     const SESSION_ADYEN_RESTRICT_EMAILS = 'adyenRestrictEmail';
 
     /**

--- a/Components/Manager/AdyenManager.php
+++ b/Components/Manager/AdyenManager.php
@@ -35,7 +35,7 @@ class AdyenManager
         $this->session = $session;
     }
 
-    public function storePaymentDataInSession(PaymentInfo $transaction, string $paymentData)
+    public function storePaymentData(PaymentInfo $transaction, string $paymentData)
     {
         $transaction->setPaymentData($paymentData);
         $this->modelManager->persist($transaction);

--- a/Components/Manager/AdyenManager.php
+++ b/Components/Manager/AdyenManager.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace AdyenPayment\Components\Manager;
 
+use AdyenPayment\Models\PaymentInfo;
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Enlight_Components_Session_Namespace;
 use AdyenPayment\AdyenPayment;
+use Shopware\Models\Order\Order;
 
 /**
  * Class AdyenManager
@@ -32,31 +35,42 @@ class AdyenManager
         $this->session = $session;
     }
 
-    /**
-     * @param $paymentData
-     */
-    public function storePaymentDataInSession($paymentData)
+    public function storePaymentDataInSession(PaymentInfo $transaction, string $paymentData)
     {
-        $this->session->offsetSet(AdyenPayment::SESSION_ADYEN_PAYMENT_DATA, $paymentData);
+        $transaction->setPaymentData($paymentData);
+        $this->modelManager->persist($transaction);
+        $this->modelManager->flush();
     }
 
     /**
+     * @param Order|null $order
      * @return string
      */
-    public function getPaymentDataSession(): string
+    public function fetchOrderPaymentData($order): string
     {
-        return $this->session->offsetGet(AdyenPayment::SESSION_ADYEN_PAYMENT_DATA) ?? '';
+        if (!$order) {
+            return '';
+        }
+
+        /* @var PaymentInfo $transaction */
+        $transaction = $this->getPaymentInfoRepository()->findOneBy(['orderId' => $order->getId()]);
+
+        return $transaction ? $transaction->getPaymentData() : '';
     }
 
     public function unsetPaymentDataInSession()
     {
         $this->session->offsetUnset(AdyenPayment::SESSION_ADYEN_PAYMENT);
         $this->session->offsetUnset(AdyenPayment::SESSION_ADYEN_PAYMENT_VALID);
-        $this->session->offsetUnset(AdyenPayment::SESSION_ADYEN_PAYMENT_DATA);
     }
 
     public function unsetValidPaymentSession()
     {
         $this->session->offsetUnset(AdyenPayment::SESSION_ADYEN_PAYMENT_VALID);
+    }
+
+    private function getPaymentInfoRepository(): ObjectRepository
+    {
+        return $this->modelManager->getRepository(PaymentInfo::class);
     }
 }

--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -144,7 +144,7 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();
 
         $postData = $this->Request()->getPost();
-        $threeDsDetail = (string) $postData['details'][$detail] ?? '';
+        $threeDsDetail = (string) ($postData['details'][$detail] ?? $postData['details'][$post] ?? '');
         $paymentData = (string) $postData['paymentData'] ?? '';
         if (!$threeDsDetail || !$paymentData) {
             $this->logger->error('3DS2 missing data', [

--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -86,9 +86,9 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
             $checkout = $this->adyenCheckout->getCheckout();
             $paymentInfo = $checkout->payments($payload);
 
-            $this->adyenManager->storePaymentDataInSession(
+            $this->adyenManager->storePaymentData(
                 $context->getTransaction(),
-                $paymentInfo['paymentData']
+                $paymentInfo['paymentData'] ?? ''
             );
             $this->handlePaymentData($paymentInfo);
             $this->Response()->setBody(json_encode(

--- a/Controllers/Frontend/Transparent.php
+++ b/Controllers/Frontend/Transparent.php
@@ -1,5 +1,6 @@
 <?php
 
+use AdyenPayment\Utils\RequestDataFormatter;
 use Shopware\Components\CSRFWhitelistAware;
 use Shopware\Components\Logger;
 
@@ -49,7 +50,7 @@ class Shopware_Controllers_Frontend_Transparent extends Shopware_Controllers_Fro
 
         //Getting all GET parameters except for Shopware's action, controller and module
         $getParams = $request->getQuery();
-        unset($getParams['action'], $getParams['controller'], $getParams['module']);
+        $getParams = RequestDataFormatter::forRedirect($getParams);
 
         //Filtering allowed POST parameters
         $fullPostParams = $request->getParams();

--- a/Models/PaymentInfo.php
+++ b/Models/PaymentInfo.php
@@ -65,6 +65,12 @@ class PaymentInfo extends ModelEntity
      */
     private $ordermailVariables;
 
+    /**
+     * @var string
+     * @ORM\Column(name="payment_data", type="text", nullable=true)
+     */
+    private $paymentData;
+
     public function __construct()
     {
         $this->setCreatedAt(new \DateTime('now'));
@@ -81,11 +87,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param int $id
+     *
      * @return $this
      */
     public function setId(int $id)
     {
         $this->id = $id;
+
         return $this;
     }
 
@@ -99,11 +107,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param int $orderId
+     *
      * @return $this
      */
     public function setOrderId(int $orderId)
     {
         $this->orderId = $orderId;
+
         return $this;
     }
 
@@ -118,11 +128,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param Order|null $order
+     *
      * @return $this
      */
     public function setOrder(Order $order = null)
     {
         $this->order = $order;
+
         return $this;
     }
 
@@ -138,11 +150,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param string $pspReference
+     *
      * @return $this
      */
     public function setPspReference(string $pspReference)
     {
         $this->pspReference = $pspReference;
+
         return $this;
     }
 
@@ -156,11 +170,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param \DateTime $createdAt
+     *
      * @return $this
      */
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
         return $this;
     }
 
@@ -174,11 +190,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param \DateTime $updatedAt
+     *
      * @return $this
      */
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
         return $this;
     }
 
@@ -192,11 +210,13 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param string $resultCode
+     *
      * @return $this
      */
     public function setResultCode(string $resultCode)
     {
         $this->resultCode = $resultCode;
+
         return $this;
     }
 
@@ -210,11 +230,25 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @param string|null $ordermailVariables
+     *
      * @return $this
      */
     public function setOrdermailVariables($ordermailVariables)
     {
         $this->ordermailVariables = $ordermailVariables;
+
+        return $this;
+    }
+
+    public function getPaymentData(): string
+    {
+        return $this->paymentData;
+    }
+
+    public function setPaymentData(string $paymentData): self
+    {
+        $this->paymentData = $paymentData;
+
         return $this;
     }
 }

--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -131,7 +131,7 @@
 
         handlePaymentDataIdentifyShopper: function (data) {
             var me = this;
-
+            var paymentData = data.paymentData;
             $(me.opts.placeOrderSelector).parent().append('<div id="AdyenIdentifyShopperThreeDS2"/>');
             me.adyenCheckout
                 .create('threeDS2DeviceFingerprint', {
@@ -141,7 +141,10 @@
                             method: 'POST',
                             dataType: 'json',
                             url: me.opts.adyenAjaxIdentifyShopperUrl,
-                            data: fingerprintData.data.details,
+                            data: {
+                                'details': fingerprintData.data.details,
+                                'paymentData': paymentData
+                            },
                             success: function (response) {
                                 me.handlePaymentData(response);
                             },
@@ -156,7 +159,7 @@
 
         handlePaymentDataChallengeShopper: function (data) {
             var me = this;
-
+            var paymentData = data.paymentData;
             var modal = $.modal.open('<div id="AdyenChallengeShopperThreeDS2"/>', {
                 showCloseButton: false,
                 closeOnOverlay: false,
@@ -171,7 +174,10 @@
                             method: 'POST',
                             dataType: 'json',
                             url: me.opts.adyenAjaxChallengeShopperUrl,
-                            data: challengeData.data.details,
+                            data: {
+                                'details': challengeData.data.details,
+                                'paymentData': paymentData
+                            },
                             success: function (response) {
                                 me.handlePaymentData(response);
                             },

--- a/Utils/RequestDataFormatter.php
+++ b/Utils/RequestDataFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Utils;
+
+final class RequestDataFormatter
+{
+    const SHOPWARE_KEYS = ['module' => null, 'controller' => null, 'action' => null];
+
+    public static function forRedirect(array $data): array
+    {
+        if (!$data) {
+            return [];
+        }
+
+        return array_diff_key($data, self::SHOPWARE_KEYS);
+    }
+
+    public static function forPaymentDetails(array $data): array
+    {
+        if (!$data) {
+            return [];
+        }
+
+        return array_diff_key($data, array_merge(self::SHOPWARE_KEYS, ['merchantReference' => null]));
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Store payment data in DB (session has data loss)
Update 3DS2 for payment data handling
Update 3DS1 payment/details data handling parameter mismatch for request

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
* 3DS1: Mastercard Kredikarte (scheme)
  * Enrolled card: Mastercard Kredikarte (scheme)
  * Enrolled card: Maestro Kredikarte (scheme)
  * Card not enrolled: Visa Kredikarte (scheme)
* 3DS2:
  * Fingerprint Mastercard Kredikarte (scheme)
  * ChallengeShopper: Visa Kredikarte (scheme)
  * Frictionless: Visa Kredikarte (scheme)

**Fixed issue**:  #108 
