### PR TITLE
[PW-3933] Getting Adyen config data from the CheckoutSubscriber if not present in the session storage

### DIFF
--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -276,13 +276,26 @@
 
             var adyenConfig = me.getAdyenConfigSession();
 
-            me.adyenConfiguration = {
-                locale: adyenConfig.locale,
-                environment: adyenConfig.environment,
-                originKey: adyenConfig.originKey,
-                paymentMethodsResponse: adyenConfig.paymentMethodsResponse,
-                onAdditionalDetails: $.proxy(me.handleOnAdditionalDetails, me),
-            };
+            if (adyenConfig) {
+                //Get the config data from the session
+                me.adyenConfiguration = {
+                    locale: adyenConfig.locale,
+                    environment: adyenConfig.environment,
+                    originKey: adyenConfig.originKey,
+                    paymentMethodsResponse: adyenConfig.paymentMethodsResponse,
+                    onAdditionalDetails: $.proxy(me.handleOnAdditionalDetails, me)
+                };
+            } else {
+                //Get the config data from the CheckoutSubscriber
+                var adyenConfigObj = document.querySelector('.adyen-payment-selection.adyen-config').dataset;
+                me.adyenConfiguration = {
+                    locale: adyenConfigObj.shoplocale,
+                    environment: adyenConfigObj.adyenenvironment,
+                    originKey: adyenConfigObj.adyenoriginkey,
+                    paymentMethodsResponse: JSON.parse(adyenConfigObj.adyenpaymentmethodsresponse),
+                    onAdditionalDetails: $.proxy(me.handleOnAdditionalDetails, me)
+                };
+            }
         },
 
         setCheckout: function () {

--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -274,28 +274,19 @@
         setConfig: function () {
             var me = this;
 
-            var adyenConfig = me.getAdyenConfigSession();
+            var adyenConfigSession = JSON.parse(me.getAdyenConfigSession());
+            var adyenConfigTpl = document.querySelector('.adyen-payment-selection.adyen-config').dataset;
 
-            if (adyenConfig) {
-                //Get the config data from the session
-                me.adyenConfiguration = {
-                    locale: adyenConfig.locale,
-                    environment: adyenConfig.environment,
-                    originKey: adyenConfig.originKey,
-                    paymentMethodsResponse: adyenConfig.paymentMethodsResponse,
-                    onAdditionalDetails: me.handleOnAdditionalDetails.bind(me)
-                };
-            } else {
-                //Get the config data from the CheckoutSubscriber
-                var adyenConfigObj = document.querySelector('.adyen-payment-selection.adyen-config').dataset;
-                me.adyenConfiguration = {
-                    locale: adyenConfigObj.shoplocale,
-                    environment: adyenConfigObj.adyenenvironment,
-                    originKey: adyenConfigObj.adyenoriginkey,
-                    paymentMethodsResponse: JSON.parse(adyenConfigObj.adyenpaymentmethodsresponse),
-                    onAdditionalDetails: me.handleOnAdditionalDetails.bind(me)
-                };
-            }
+            me.adyenConfiguration = {
+                locale: adyenConfigSession ? adyenConfigSession.locale : adyenConfigTpl.shoplocale,
+                environment: adyenConfigSession ? adyenConfigSession.environment : adyenConfigTpl.adyenenvironment,
+                originKey: adyenConfigSession ? adyenConfigSession.originkey : adyenConfigTpl.adyenoriginkey,
+                paymentMethodsResponse:
+                    adyenConfigSession
+                        ? adyenConfigSession.paymentMethodsResponse
+                        : JSON.parse(adyenConfigTpl.adyenpaymentmethodsresponse),
+                onAdditionalDetails: me.handleOnAdditionalDetails.bind(me)
+            };
         },
 
         setCheckout: function () {

--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -283,7 +283,7 @@
                     environment: adyenConfig.environment,
                     originKey: adyenConfig.originKey,
                     paymentMethodsResponse: adyenConfig.paymentMethodsResponse,
-                    onAdditionalDetails: $.proxy(me.handleOnAdditionalDetails, me)
+                    onAdditionalDetails: me.handleOnAdditionalDetails.bind(me)
                 };
             } else {
                 //Get the config data from the CheckoutSubscriber
@@ -293,7 +293,7 @@
                     environment: adyenConfigObj.adyenenvironment,
                     originKey: adyenConfigObj.adyenoriginkey,
                     paymentMethodsResponse: JSON.parse(adyenConfigObj.adyenpaymentmethodsresponse),
-                    onAdditionalDetails: $.proxy(me.handleOnAdditionalDetails, me)
+                    onAdditionalDetails: me.handleOnAdditionalDetails.bind(me)
                 };
             }
         },

--- a/Resources/views/frontend/checkout/adyen_configuration.tpl
+++ b/Resources/views/frontend/checkout/adyen_configuration.tpl
@@ -1,0 +1,10 @@
+{if $sAdyenConfig}
+    <div data-shopLocale='{$sAdyenConfig.shopLocale}'
+         data-adyenOriginKey='{$sAdyenConfig.originKey}'
+         data-adyenEnvironment='{$sAdyenConfig.environment}'
+         data-adyenPaymentMethodsResponse='{$sAdyenConfig.paymentMethods}'
+         data-resetSessionUrl='{url controller="Adyen" action="ResetValidPaymentSession"}'
+         {if $mAdyenSnippets}data-adyensnippets="{$mAdyenSnippets}"{/if}
+         class="adyen-payment-selection adyen-config">
+    </div>
+{/if}

--- a/Resources/views/frontend/checkout/change_payment.tpl
+++ b/Resources/views/frontend/checkout/change_payment.tpl
@@ -6,16 +6,7 @@
     {assign var="paymentMethods" value=$sPayments.paymentMethods}
     {assign var="storedPaymentMethods" value=$sPayments.storedPaymentMethods}
 
-    {if $sAdyenConfig}
-        <div data-shopLocale='{$sAdyenConfig.shopLocale}'
-             data-adyenOriginKey='{$sAdyenConfig.originKey}'
-             data-adyenEnvironment='{$sAdyenConfig.environment}'
-             data-adyenPaymentMethodsResponse='{$sAdyenConfig.paymentMethods}'
-             data-resetSessionUrl='{url controller="Adyen" action="ResetValidPaymentSession"}'
-             {if $mAdyenSnippets}data-adyensnippets="{$mAdyenSnippets}"{/if}
-             class="adyen-payment-selection">
-        </div>
-    {/if}
+    {include file="frontend/checkout/adyen_configuration.tpl"}
 
     {block name='frontend_checkout_payment_content_adyen_stored_payment_methods'}
         {if !empty($storedPaymentMethods)}

--- a/Resources/views/frontend/checkout/confirm.tpl
+++ b/Resources/views/frontend/checkout/confirm.tpl
@@ -18,7 +18,6 @@
 
 {block name='frontend_index_body_attributes'}
     {$smarty.block.parent}
-    {if $mAdyenSnippets}data-AdyenSnippets="{$mAdyenSnippets}"{/if}
     data-adyenAjaxDoPaymentUrl="{url module='frontend' controller='adyen' action='ajaxDoPayment'}"
     data-adyenAjaxIdentifyShopperUrl="{url module='frontend' controller='adyen' action='ajaxIdentifyShopper'}"
     data-adyenAjaxChallengeShopperUrl="{url module='frontend' controller='adyen' action='ajaxChallengeShopper'}"
@@ -38,6 +37,12 @@
         data-adyenIsAdyenPayment='true'
     {/if}
 {/block}
+
+{block name='frontend_checkout_confirm_payment_method_panel'}
+    {$smarty.block.parent}
+    {include file="frontend/checkout/adyen_configuration.tpl"}
+{/block}
+
 
 {block name='frontend_checkout_confirm_error_messages'}
     <div data-adyen-checkout-error="true"></div>

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -205,7 +205,7 @@ class CheckoutSubscriber implements SubscriberInterface
         /** @var Shopware_Controllers_Frontend_Checkout $subject */
         $subject = $args->getSubject();
 
-        if (!in_array($subject->Request()->getActionName(), ['shippingPayment'])) {
+        if (!in_array($subject->Request()->getActionName(), ['shippingPayment', 'confirm'])) {
             return;
         }
         $view = $subject->View();


### PR DESCRIPTION
## Summary
When there's a payment method selected and no initialization of the Adyen config in the session the order can't be placed. In this PR a fallback to the data provided by the CheckoutSubscriber is introduced.

## Tested scenarios
Successful payment with Paypal -> New payment with payment method preselected

**Fixed issue**:  PW-3933
