### PR TITLE
[PW-3959] Using 'ordernumber' to fetch order mail variables

### DIFF
--- a/AdyenPayment.php
+++ b/AdyenPayment.php
@@ -38,6 +38,7 @@ class AdyenPayment extends Plugin
     const SESSION_ADYEN_PAYMENT = 'adyenPayment';
     const SESSION_ADYEN_PAYMENT_VALID = 'adyenPaymentValid';
     const SESSION_ADYEN_RESTRICT_EMAILS = 'adyenRestrictEmail';
+    const SESSION_ADYEN_PAYMENT_INFO_ID = 'adyenPaymentInfoId';
 
     /**
      * @return bool

--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -204,6 +204,11 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
             (bool)(0 < $transaction->getId())
         );
 
+        Shopware()->Session()->offsetSet(
+            AdyenPayment::SESSION_ADYEN_PAYMENT_INFO_ID,
+            $transaction->getId()
+        );
+
         $orderNumber = $this->saveOrder(
             $transaction->getId(),
             $signature,

--- a/Models/PaymentInfo.php
+++ b/Models/PaymentInfo.php
@@ -67,6 +67,12 @@ class PaymentInfo extends ModelEntity
 
     /**
      * @var string
+     * @ORM\Column(name="ordernumber", type="string", length=255, nullable=true)
+     */
+    private $ordernumber;
+
+    /**
+     * @var string
      * @ORM\Column(name="payment_data", type="text", nullable=true)
      */
     private $paymentData;
@@ -236,6 +242,26 @@ class PaymentInfo extends ModelEntity
     public function setOrdermailVariables($ordermailVariables)
     {
         $this->ordermailVariables = $ordermailVariables;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOrdernumber()
+    {
+        return $this->ordernumber;
+    }
+
+    /**
+     * @param string|null $ordernumber
+     *
+     * @return $this
+     */
+    public function setOrderNumber($ordernumber)
+    {
+        $this->ordernumber = $ordernumber;
 
         return $this;
     }

--- a/Subscriber/OrderEmailSubscriber.php
+++ b/Subscriber/OrderEmailSubscriber.php
@@ -70,6 +70,7 @@ class OrderEmailSubscriber implements SubscriberInterface
                 $this->modelManager->flush($paymentInfo);
             }
         }
+        return $args->getReturn();
     }
 
     public function shouldStopEmailSending(Enlight_Event_EventArgs $args)

--- a/Subscriber/OrderEmailSubscriber.php
+++ b/Subscriber/OrderEmailSubscriber.php
@@ -122,6 +122,5 @@ class OrderEmailSubscriber implements SubscriberInterface
         return $this->orderRepository->findOneBy([
             'id' => $orderId
         ])->getNumber();
-
     }
 }

--- a/Subscriber/OrderEmailSubscriber.php
+++ b/Subscriber/OrderEmailSubscriber.php
@@ -74,7 +74,6 @@ class OrderEmailSubscriber implements SubscriberInterface
 
     public function shouldStopEmailSending(Enlight_Event_EventArgs $args)
     {
-        $orderId = $args->get('orderId');
         $variables = $args->get('variables');
 
         if (AdyenPayment::ADYEN_GENERAL_PAYMENT_METHOD === $variables['additional']['payment']['name']
@@ -83,7 +82,7 @@ class OrderEmailSubscriber implements SubscriberInterface
 
             /** @var PaymentInfo $paymentInfo */
             $paymentInfo = $this->paymentInfoRepository->findOneBy([
-                'orderId' => $orderId
+                'ordernumber' => $variables['ordernumber']
             ]);
 
             if ($paymentInfo && empty($paymentInfo->getOrdermailVariables())) {


### PR DESCRIPTION
## Summary
The `Shopware_Modules_Order_SendMail_Send` event is used to store the mail variables in the PaymentInfo entity to be used in the delayed mail sending process, but this event doesn't always contain the `orderId` as the order save process hasn't finished.

A fallback to the ordernumber is being added using the `adyenPaymentInfoId` session key and the `Shopware_Modules_Order_SaveOrder_ProcessDetails` event to save the ordernumber in the PaymentInfo.

## Tested scenarios
After placing an order the mail variables are stored in PaymentInfo.


**Fixed issue**: PW-3959
