### PR TITLE
AP-266 merge all payment methods in one array and filter in template

### DIFF
--- a/Resources/views/frontend/checkout/change_payment.tpl
+++ b/Resources/views/frontend/checkout/change_payment.tpl
@@ -3,8 +3,16 @@
 {block name='frontend_checkout_payment_content'}
     {include file="frontend/checkout/adyen_libaries.tpl"}
 
-    {assign var="paymentMethods" value=$sPayments.paymentMethods}
-    {assign var="storedPaymentMethods" value=$sPayments.storedPaymentMethods}
+    {* Filter on storedPayments and default payment methods (SW 5 needs internally array<int, array> for $sPayments) *}
+    {assign var="paymentMethods" value=[]}
+    {assign var="storedPaymentMethods" value=[]}
+    {foreach $sPayments as $paymentMethod}
+        {if 'isStoredPayment'|array_key_exists:$paymentMethod && true === $paymentMethod.isStoredPayment}
+            {$storedPaymentMethods[] = $paymentMethod}
+        {else}
+            {$paymentMethods[] = $paymentMethod}
+        {/if}
+    {/foreach}
 
     {include file="frontend/checkout/adyen_configuration.tpl"}
 

--- a/Serializer/Payment/PaymentMethodSerializer.php
+++ b/Serializer/Payment/PaymentMethodSerializer.php
@@ -40,21 +40,20 @@ final class PaymentMethodSerializer
         $defaultPaymentMethods = $adyenPaymentMethods->filterByPaymentType(PaymentMethodType::default());
         $storedPaymentMethods = $adyenPaymentMethods->filterByPaymentType(PaymentMethodType::stored());
 
-        return [
-            'paymentMethods' => array_merge(
-                $defaultPaymentMethods->map(
-                    function (PaymentMethod $adyenMethod) use ($defaultPaymentMethods) {
-                        return $this->serialize($adyenMethod, $defaultPaymentMethods);
-                    }
-                ),
-                $shopwareMethods
-            ),
-            'storedPaymentMethods' => $storedPaymentMethods->map(
+        // Shopware internally uses array<int, array> for identifying the selected payment
+        return array_merge(
+            $storedPaymentMethods->map(
                 function (PaymentMethod $adyenMethod) use ($storedPaymentMethods) {
                     return $this->serialize($adyenMethod, $storedPaymentMethods);
                 }
             ),
-        ];
+            $defaultPaymentMethods->map(
+                function (PaymentMethod $adyenMethod) use ($defaultPaymentMethods) {
+                    return $this->serialize($adyenMethod, $defaultPaymentMethods);
+                }
+            ),
+            $shopwareMethods
+        );
     }
 
     /**
@@ -79,6 +78,7 @@ final class PaymentMethodSerializer
             'description' => $name,
             'additionaldescription' => $description,
             'image' => $this->paymentMethodService->getAdyenImageByType($paymentMethod->getType()),
+            'isStoredPayment' => $paymentMethod->isStoredPayment(),
             'metadata' => $paymentMethod->getRawData(),
         ];
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Showpare 5 uses internally `array<int, array>` structure to identify Payment Methods
Updated the paymentMehtods serializer to implement SW5 list and add additional parameter for identifying stored payments.
Split up payments on selection template based on parameter.

Shipping methods are available again for enabled country and Adyen payment methods.
Shipping methods are listed below default payments.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
Test cases:
* :heavy_check_mark: default payment
* :heavy_check_mark: stored payment
* :warning: shipping method, issue during reset of payment option (see ticket: #126, not in scope of current ticket)
<!-- Description of tested scenarios -->

**Fixed issue**:  #124
