### PR TITLE
AP-268 fix issue on selecting shipping method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "monolog/monolog": "^1.0"
     },
     "require-dev": {
-        "shopware/shopware": "^5.6",
+        "shopware/shopware": "^5.6.0",
         "phpro/grumphp": "^0.16.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": "^7.0",
         "ext-json": "*",
-        "adyen/php-api-library": "^6.1"
+        "adyen/php-api-library": "^6.1",
+        "monolog/monolog": "^1.0"
     },
     "require-dev": {
         "shopware/shopware": "^5.6",

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,10 @@
     "require": {
         "php": "^7.0",
         "ext-json": "*",
-        "adyen/php-api-library": "^6.1",
-        "monolog/monolog": "^1.0"
+        "adyen/php-api-library": "^6.1"
     },
     "require-dev": {
-        "shopware/shopware": ">=5.6.0 <=5.6.9",
+        "shopware/shopware": "^5.6",
         "phpro/grumphp": "^0.16.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "monolog/monolog": "^1.0"
     },
     "require-dev": {
-        "shopware/shopware": "^5.6.0",
+        "shopware/shopware": ">=5.6.0 <=5.6.9",
         "phpro/grumphp": "^0.16.1",
         "phpcompatibility/php-compatibility": "^9.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Fix payment data (browser storage) lost when selecting a shipping method.

Note: when selecting a shipping method, the payment data needs to be re-entered 
_(this was working the same before this change)_

@acampos1916 maybe create a ticket to adjust the working: payment data not lost on selecting a shipping method?
Due note that currently Shopware is handling the shipping selection with an ajax call and replacing the form, 
it could be complex to alter the current working.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
Test cases:
* select Credit card, select shipping method (data needs to stay as is)
* select Credit Card, selecting non-adyen payment method (data needs to be cleared)
* select Credit Card, select another adyen payment method  (data needs to update to new state)
* complete payment flow
<!-- Description of tested scenarios -->

Explicit test on Shopware version 5.6.7:

**Fixed issue**: #126  <!-- #-prefixed issue number -->
