### PR TITLE
Catch user that has no adyen payment preselected

### DIFF
--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -435,7 +435,7 @@ class CheckoutSubscriber implements SubscriberInterface
 
         $selectedType = $userData['additional']['user'][AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD];
         
-        if($selectedType === null) {
+        if ($selectedType === null) {
             return true;
         }
         

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -434,6 +434,11 @@ class CheckoutSubscriber implements SubscriberInterface
 
 
         $selectedType = $userData['additional']['user'][AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD];
+        
+        if($selectedType === null) {
+            return true;
+        }
+        
         $adyenPaymentMethods = PaymentMethodCollection::fromAdyenMethods(
             $this->paymentMethodService->getPaymentMethods($countryCode, $currency, $value)
         );


### PR DESCRIPTION
## Summary
If a user has no preselected adyen payment an error occurs:
![image](https://user-images.githubusercontent.com/5836639/107222962-e2fcae00-6a15-11eb-9af8-07f0b47dc167.png)

But Method fetchByTypeOrId() doesn't allow null values. 

## Tested scenarios
Set s_user_attributes.adyen_payment_payment_method to NULL or create a new User and go to the checkout.

