### PR TITLE
[PW-4128] Hiding PM and Stored PM group title if the other group is empty

### DIFF
--- a/Resources/frontend/less/all.less
+++ b/Resources/frontend/less/all.less
@@ -31,3 +31,7 @@
 .alert.is--adyen-error {
   margin-bottom: 12px;
 }
+
+.adyen-method-section-title {
+    text-indent: 1em;
+}

--- a/Resources/views/frontend/checkout/change_payment.tpl
+++ b/Resources/views/frontend/checkout/change_payment.tpl
@@ -18,20 +18,26 @@
 
     {block name='frontend_checkout_payment_content_adyen_stored_payment_methods'}
         {if !empty($storedPaymentMethods)}
-            <h4 class="payment--method-headline panel--title is--underline">
-                {s namespace='adyen/checkout/payment' name='storedPaymentMethodTitle'}{/s}
-            </h4>
+            {if !empty($paymentMethods)}
+                <h4 class="payment--method-headline panel--title is--underline adyen-method-section-title">
+                    {s namespace='adyen/checkout/payment' name='storedPaymentMethodTitle'}{/s}
+                </h4>
+            {/if}
             {assign var=sPayments value=$storedPaymentMethods}
             {$smarty.block.parent}
         {/if}
     {/block}
 
     {block name='frontend_checkout_payment_content_adyen_payment_methods'}
-        <h4 class="payment--method-headline panel--title is--underline">
-            {s namespace='adyen/checkout/payment' name='paymentMethodTitle'}{/s}
-        </h4>
-        {assign var=sPayments value=$paymentMethods}
-        {$smarty.block.parent}
+        {if !empty($paymentMethods)}
+            {if !empty($storedPaymentMethods)}
+                <h4 class="payment--method-headline panel--title is--underline adyen-method-section-title">
+                    {s namespace='adyen/checkout/payment' name='paymentMethodTitle'}{/s}
+                </h4>
+            {/if}
+            {assign var=sPayments value=$paymentMethods}
+            {$smarty.block.parent}
+        {/if}
     {/block}
 
 {/block}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In the payment selection page Adyen lists both regular and stored payment methods with the same style as the Shopware title. In this PR an indentation is being introduced to differentiate the sections and the titles are only shown only if both groups are present.

## Tested scenarios
Only stored PMs or only regular PMs: hides the title.
Both stored PMs and regular PMs are present: both titles are shown with indentation.

**Fixed issue**:  PW-4128
