### PR TITLE
[PW-4149] add processing time to notifications

### DIFF
--- a/Components/Builder/NotificationBuilder.php
+++ b/Components/Builder/NotificationBuilder.php
@@ -94,6 +94,35 @@ class NotificationBuilder
             $notification->setErrorDetails($params['reason']);
         }
 
+        if (isset($params['eventCode']) && isset($params['success'])) {
+            $notification->setProcessedAt($this->getProcessingTime($notification));
+        }
+
         return $notification;
+    }
+
+    /**
+     * Set delay in processing time for certain notifications.
+     *
+     * @param Notification $notification
+     * @return \DateTime
+     */
+    private function getProcessingTime(Notification $notification): \DateTime
+    {
+        $processedAt = new \DateTime();
+        switch ($notification->getEventCode()) {
+            case 'AUTHORISATION':
+                if (!$notification->isSuccess()) {
+                    $processedAt = $processedAt->add(new \DateInterval('PT30M'));
+                }
+                break;
+            case 'OFFER_CLOSED':
+                $processedAt = $processedAt->add(new \DateInterval('PT30M'));
+                break;
+            default:
+                break;
+        }
+
+        return $processedAt;
     }
 }

--- a/Components/Builder/NotificationBuilder.php
+++ b/Components/Builder/NotificationBuilder.php
@@ -95,7 +95,7 @@ class NotificationBuilder
         }
 
         if (isset($params['eventCode']) && isset($params['success'])) {
-            $notification->setProcessedAt($this->getProcessingTime($notification));
+            $notification->setScheduledProcessingTime($this->getProcessingTime($notification));
         }
 
         return $notification;
@@ -109,20 +109,20 @@ class NotificationBuilder
      */
     private function getProcessingTime(Notification $notification): \DateTime
     {
-        $processedAt = new \DateTime();
+        $processingTime = new \DateTime();
         switch ($notification->getEventCode()) {
             case 'AUTHORISATION':
                 if (!$notification->isSuccess()) {
-                    $processedAt = $processedAt->add(new \DateInterval('PT30M'));
+                    $processingTime = $processingTime->add(new \DateInterval('PT30M'));
                 }
                 break;
             case 'OFFER_CLOSED':
-                $processedAt = $processedAt->add(new \DateInterval('PT30M'));
+                $processingTime = $processingTime->add(new \DateInterval('PT30M'));
                 break;
             default:
                 break;
         }
 
-        return $processedAt;
+        return $processingTime;
     }
 }

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -56,7 +56,6 @@ class IncomingNotificationManager
      */
     public function convertNotifications(array $textNotifications)
     {
-        // @todo PW-4149 check each one and add field to determine if it's ready for processing or should be skipped
         foreach ($textNotifications as $textNotificationItem) {
             try {
                 if (!empty($textNotificationItem->getTextNotification())) {

--- a/Components/IncomingNotificationManager.php
+++ b/Components/IncomingNotificationManager.php
@@ -56,6 +56,7 @@ class IncomingNotificationManager
      */
     public function convertNotifications(array $textNotifications)
     {
+        // @todo PW-4149 check each one and add field to determine if it's ready for processing or should be skipped
         foreach ($textNotifications as $textNotificationItem) {
             try {
                 if (!empty($textNotificationItem->getTextNotification())) {

--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -57,7 +57,7 @@ class NotificationManager
             ->setParameter('processingTime', new \DateTime())
             ->setMaxResults(1);
 
-        return $builder->getQuery()->getSQL();
+        return $builder->getQuery()->getSingleResult();
     }
 
     /**

--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -47,6 +47,7 @@ class NotificationManager
      */
     public function getNextNotificationToHandle()
     {
+        // @todo PW-4149 add clause to skip notifications that should be skipped
         $builder = $this->notificationRepository->createQueryBuilder('n');
         $builder->where("n.status = :statusReceived OR n.status = :statusRetry")
             ->orderBy('n.updatedAt', 'ASC')

--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use AdyenPayment\Models\Enum\NotificationStatus;
 use AdyenPayment\Models\Notification;
+use Shopware\Components\Form\Field\Date;
 use Shopware\Components\Model\ModelManager;
 
 /**
@@ -47,15 +48,16 @@ class NotificationManager
      */
     public function getNextNotificationToHandle()
     {
-        // @todo PW-4149 add clause to skip notifications that should be skipped
         $builder = $this->notificationRepository->createQueryBuilder('n');
         $builder->where("n.status = :statusReceived OR n.status = :statusRetry")
+            ->where('(n.processedAt <= :processingTime OR n.processedAt IS NULL)')
             ->orderBy('n.updatedAt', 'ASC')
             ->setParameter('statusReceived', NotificationStatus::STATUS_RECEIVED)
             ->setParameter('statusRetry', NotificationStatus::STATUS_RETRY)
+            ->setParameter('processingTime', new \DateTime())
             ->setMaxResults(1);
 
-        return $builder->getQuery()->getSingleResult();
+        return $builder->getQuery()->getSQL();
     }
 
     /**

--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use AdyenPayment\Models\Enum\NotificationStatus;
 use AdyenPayment\Models\Notification;
-use Shopware\Components\Form\Field\Date;
 use Shopware\Components\Model\ModelManager;
 
 /**

--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -49,7 +49,7 @@ class NotificationManager
     {
         $builder = $this->notificationRepository->createQueryBuilder('n');
         $builder->where("n.status = :statusReceived OR n.status = :statusRetry")
-            ->where('(n.processedAt <= :processingTime OR n.processedAt IS NULL)')
+            ->where('(n.scheduledProcessingTime <= :processingTime OR n.scheduledProcessingTime IS NULL)')
             ->orderBy('n.updatedAt', 'ASC')
             ->setParameter('statusReceived', NotificationStatus::STATUS_RECEIVED)
             ->setParameter('statusRetry', NotificationStatus::STATUS_RETRY)

--- a/Models/Notification.php
+++ b/Models/Notification.php
@@ -53,6 +53,12 @@ class Notification extends ModelEntity implements \JsonSerializable
     private $updatedAt;
 
     /**
+     * @var \DateTime
+     * @ORM\Column(name="processed_at", type="datetime", nullable=true)
+     */
+    private $processedAt;
+
+    /**
      * @var string
      * @ORM\Column(name="status", type="text")
      */
@@ -214,6 +220,24 @@ class Notification extends ModelEntity implements \JsonSerializable
     public function setUpdatedAt(\DateTime $updatedAt): Notification
     {
         $this->updatedAt = $updatedAt;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getProcessedAt(): \DateTime
+    {
+        return $this->processedAt;
+    }
+
+    /**
+     * @param \DateTime $processedAt
+     * @return Notification
+     */
+    public function setProcessedAt(\DateTime $processedAt): Notification
+    {
+        $this->processedAt = $processedAt;
         return $this;
     }
 

--- a/Models/Notification.php
+++ b/Models/Notification.php
@@ -54,9 +54,9 @@ class Notification extends ModelEntity implements \JsonSerializable
 
     /**
      * @var \DateTime
-     * @ORM\Column(name="processed_at", type="datetime", nullable=true)
+     * @ORM\Column(name="scheduled_processing_time", type="datetime", nullable=true)
      */
-    private $processedAt;
+    private $scheduledProcessingTime;
 
     /**
      * @var string
@@ -226,18 +226,18 @@ class Notification extends ModelEntity implements \JsonSerializable
     /**
      * @return \DateTime
      */
-    public function getProcessedAt(): \DateTime
+    public function getScheduledProcessingTime(): \DateTime
     {
-        return $this->processedAt;
+        return $this->scheduledProcessingTime;
     }
 
     /**
-     * @param \DateTime $processedAt
+     * @param \DateTime $scheduledProcessingTime
      * @return Notification
      */
-    public function setProcessedAt(\DateTime $processedAt): Notification
+    public function setScheduledProcessingTime(\DateTime $scheduledProcessingTime): Notification
     {
-        $this->processedAt = $processedAt;
+        $this->scheduledProcessingTime = $scheduledProcessingTime;
         return $this;
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
OFFER_CLOSED and AUTHORISATION notification with success=false should be processed after awhile
This PR introduces a new column to indicate when a notification should be processed, 
adds `where` clause to use the processing time, where available, in selecting next notifications for processing.
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  #141 <!-- #-prefixed issue number -->
