### PR TITLE
Ap 264 add psp reference on authorization success notification

### DIFF
--- a/Components/Manager/OrderManager.php
+++ b/Components/Manager/OrderManager.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Components\Manager;
+
+use Doctrine\ORM\EntityManager;
+use Shopware\Models\Order\Order;
+use Shopware\Models\Order\Status;
+
+final class OrderManager implements OrderManagerInterface
+{
+    /**
+     * @var EntityManager
+     */
+    private $modelManager;
+
+    public function __construct(EntityManager $modelManager)
+    {
+        $this->modelManager = $modelManager;
+    }
+
+    public function save(Order $order)
+    {
+        $this->modelManager->persist($order);
+        $this->modelManager->flush($order);
+    }
+
+    public function updatePspReference(Order $order, string $pspReference)
+    {
+        $order = $order->setTransactionId($pspReference);
+        $this->modelManager->persist($order);
+    }
+
+    public function updateOrderPayment(Order $order, string $pspReference, Status $paymentStatus)
+    {
+        $order->setPaymentStatus($paymentStatus);
+        $order = $order->setTransactionId($pspReference);
+        $this->modelManager->persist($order);
+    }
+}

--- a/Components/Manager/OrderManager.php
+++ b/Components/Manager/OrderManager.php
@@ -32,7 +32,7 @@ final class OrderManager implements OrderManagerInterface
         $this->modelManager->persist($order);
     }
 
-    public function updateOrderPayment(Order $order, string $pspReference, Status $paymentStatus)
+    public function updatePayment(Order $order, string $pspReference, Status $paymentStatus)
     {
         $order->setPaymentStatus($paymentStatus);
         $order = $order->setTransactionId($pspReference);

--- a/Components/Manager/OrderManagerInterface.php
+++ b/Components/Manager/OrderManagerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Components\Manager;
+
+use Shopware\Models\Order\Order;
+use Shopware\Models\Order\Status;
+
+interface OrderManagerInterface
+{
+    public function save(Order $order);
+    public function updatePspReference(Order $order, string $pspReference);
+    public function updateOrderPayment(Order $order, string $pspReference, Status $paymentStatus);
+}

--- a/Components/Manager/OrderManagerInterface.php
+++ b/Components/Manager/OrderManagerInterface.php
@@ -11,5 +11,5 @@ interface OrderManagerInterface
 {
     public function save(Order $order);
     public function updatePspReference(Order $order, string $pspReference);
-    public function updateOrderPayment(Order $order, string $pspReference, Status $paymentStatus);
+    public function updatePayment(Order $order, string $pspReference, Status $paymentStatus);
 }

--- a/Controllers/Frontend/Process.php
+++ b/Controllers/Frontend/Process.php
@@ -1,6 +1,5 @@
 <?php
 
-use AdyenPayment\Components\Manager\AdyenManager;
 use AdyenPayment\Models\Enum\PaymentResultCodes;
 use AdyenPayment\Utils\RequestDataFormatter;
 use Shopware\Components\CSRFWhitelistAware;
@@ -15,7 +14,7 @@ use Shopware\Models\Order\Status;
 class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Frontend_Payment implements CSRFWhitelistAware
 {
     /**
-     * @var AdyenManager
+     * @var \AdyenPayment\Components\Manager\AdyenManager
      */
     private $adyenManager;
 
@@ -38,6 +37,10 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
      * @var Logger
      */
     private $logger;
+    /**
+     * @var \AdyenPayment\Components\Manager\OrderManagerInterface
+     */
+    private $orderManager;
 
 
     /**
@@ -55,6 +58,7 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
         $this->basketService = $this->get('adyen_payment.components.basket_service');
         $this->orderMailService = $this->get('adyen_payment.components.order_mail_service');
         $this->logger = $this->get('adyen_payment.logger');
+        $this->orderManager = $this->get('AdyenPayment\Components\Manager\OrderManager');
     }
 
     /**
@@ -142,9 +146,11 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
                 break;
         }
 
-        $order->setPaymentStatus($paymentStatus);
-        $order->setTransactionId($result['pspReference']);
-        $this->getModelManager()->persist($order);
+        $this->orderManager->updateOrderPayment(
+            $order,
+            (string) ($result['pspReference'] ?? ''),
+            $paymentStatus
+        );
     }
 
     /**

--- a/Controllers/Frontend/Process.php
+++ b/Controllers/Frontend/Process.php
@@ -146,7 +146,7 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
                 break;
         }
 
-        $this->orderManager->updateOrderPayment(
+        $this->orderManager->updatePayment(
             $order,
             (string) ($result['pspReference'] ?? ''),
             $paymentStatus

--- a/Resources/services/managers.xml
+++ b/Resources/services/managers.xml
@@ -11,6 +11,10 @@
                  class="AdyenPayment\Components\NotificationManager">
             <argument type="service" id="models"/>
         </service>
+        <service id="AdyenPayment\Components\Manager\OrderManager">
+            <argument type="service" id="models"/>
+        </service>
+        <service id="AdyenPayment\Components\Manager\OrderManagerInterface" alias="AdyenPayment\Components\Manager\OrderManager" />
         <service id="adyen_payment.components.text_notification_manager"
                  class="AdyenPayment\Components\TextNotificationManager">
             <argument type="service" id="models"/>

--- a/Resources/services/subscribers.xml
+++ b/Resources/services/subscribers.xml
@@ -66,5 +66,9 @@
             <tag name="shopware.event_subscriber"/>
             <argument type="service" id="adyen_payment.logger.notifications"/>
         </service>
+        <service id="AdyenPayment\Subscriber\Notification\UpdateOrderPsPSubscriber">
+            <argument type="service" id="AdyenPayment\Components\Manager\OrderManager"/>
+            <tag name="shopware.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/Subscriber/Cronjob/ProcessNotifications.php
+++ b/Subscriber/Cronjob/ProcessNotifications.php
@@ -81,7 +81,6 @@ class ProcessNotifications implements SubscriberInterface
     public function runCronjob(Shopware_Components_Cron_CronJob $job)
     {
         $textNotifications = $this->fifoTextNotificationLoader->get();
-
         $this->incomingNotificationManager->convertNotifications($textNotifications);
 
         /** @var \Generator<NotificationProcessorFeedback> $feedback */

--- a/Subscriber/Notification/UpdateOrderPsPSubscriber.php
+++ b/Subscriber/Notification/UpdateOrderPsPSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdyenPayment\Subscriber\Notification;
+
+use AdyenPayment\Components\Manager\OrderManagerInterface;
+use AdyenPayment\Models\Event;
+use Enlight\Event\SubscriberInterface;
+use Enlight_Event_EventArgs;
+
+class UpdateOrderPsPSubscriber implements SubscriberInterface
+{
+    /**
+     * @var OrderManagerInterface
+     */
+    private $orderManager;
+
+    public function __construct(OrderManagerInterface $orderManager)
+    {
+        $this->orderManager = $orderManager;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Event::NOTIFICATION_PROCESS_AUTHORISATION => '__invoke',
+        ];
+    }
+
+    public function __invoke(Enlight_Event_EventArgs $args)
+    {
+        /**
+         * @var \Shopware\Models\Order\Order      $order
+         * @var \AdyenPayment\Models\Notification $notification
+         */
+        $order = $args->get('order');
+        $notification = $args->get('notification');
+        if (!$notification->isSuccess()) {
+            return;
+        }
+
+        if ($order->getTransactionId() === $notification->getPspReference()) {
+            return;
+        }
+
+        $this->orderManager->updatePspReference($order, $notification->getPspReference());
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
* Updated authorization success notification to set pspReference on success.
* Unified the pspReference updating process in the plugin

## Tested scenarios
* Authorization success notification  (coming from Adyen)
* return process when making Paypall payment

**Fixed issue**:  #122 
