### PR TITLE
[PW-4165] Support for MANUAL_REVIEW_ACCEPT and MANUAL_REVIEW_REJECT notifications

### DIFF
--- a/Components/Builder/NotificationBuilder.php
+++ b/Components/Builder/NotificationBuilder.php
@@ -78,6 +78,8 @@ class NotificationBuilder
 
         if (isset($params['paymentMethod'])) {
             $notification->setPaymentMethod($params['paymentMethod']);
+        } elseif (isset($params['additionalData']['paymentMethodVariant'])) {
+            $notification->setPaymentMethod($params['additionalData']['paymentMethodVariant']);
         }
 
         if (isset($params['success'])) {

--- a/Components/Configuration.php
+++ b/Components/Configuration.php
@@ -193,6 +193,15 @@ class Configuration
     }
 
     /**
+     * @param bool $shop
+     * @return string
+     */
+    public function getManualReviewRejectAction($shop = false): string
+    {
+        return (string)$this->getConfig('manual_review_rejected_action', $shop);
+    }
+
+    /**
      * @return string
      */
     public function getPaymentMethodPrefix(): string

--- a/Components/NotificationProcessor/ManualReviewAccept.php
+++ b/Components/NotificationProcessor/ManualReviewAccept.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AdyenPayment\Components\NotificationProcessor;
+
+use AdyenPayment\Models\Event;
+use AdyenPayment\Models\Notification;
+use Shopware\Components\ContainerAwareEventManager;
+
+/**
+ * Class ManualReviewReject
+ * @package AdyenPayment\Components\NotificationProcessor
+ */
+class ManualReviewAccept implements NotificationProcessorInterface
+{
+    const EVENT_CODE = 'MANUAL_REVIEW_ACCEPT';
+
+    /**
+     * @var ContainerAwareEventManager
+     */
+    private $eventManager;
+
+    /**
+     * Cancellation constructor.
+     * @param ContainerAwareEventManager $eventManager
+     */
+    public function __construct(
+        ContainerAwareEventManager $eventManager
+    ) {
+        $this->eventManager = $eventManager;
+    }
+
+    /**
+     * Returns boolean on whether this processor can process the Notification object
+     *
+     * @param Notification $notification
+     * @return boolean
+     */
+    public function supports(Notification $notification): bool
+    {
+        return strtoupper($notification->getEventCode()) === self::EVENT_CODE;
+    }
+
+    /**
+     * Actual processing of the notification
+     *
+     * @param Notification $notification
+     * @throws \Enlight_Event_Exception
+     */
+    public function process(Notification $notification)
+    {
+        $order = $notification->getOrder();
+
+        $this->eventManager->notify(
+            Event::NOTIFICATION_PROCESS_CANCELLATION,
+            [
+                'order' => $order,
+                'notification' => $notification
+            ]
+        );
+    }
+}

--- a/Components/NotificationProcessor/ManualReviewReject.php
+++ b/Components/NotificationProcessor/ManualReviewReject.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace AdyenPayment\Components\NotificationProcessor;
+
+use AdyenPayment\Components\PaymentStatusUpdate;
+use AdyenPayment\Models\Event;
+use AdyenPayment\Models\Notification;
+use Psr\Log\LoggerInterface;
+use Shopware\Components\ContainerAwareEventManager;
+use Shopware\Models\Order\Status;
+use AdyenPayment\Components\Configuration;
+
+/**
+ * Class ManualReviewReject
+ * @package AdyenPayment\Components\NotificationProcessor
+ */
+class ManualReviewReject implements NotificationProcessorInterface
+{
+    const EVENT_CODE = 'MANUAL_REVIEW_REJECT';
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var ContainerAwareEventManager
+     */
+    private $eventManager;
+    /**
+     * @var PaymentStatusUpdate
+     */
+    private $paymentStatusUpdate;
+
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * Cancellation constructor.
+     * @param LoggerInterface $logger
+     * @param ContainerAwareEventManager $eventManager
+     * @param PaymentStatusUpdate $paymentStatusUpdate
+     * @param Configuration $configuration
+     */
+    public function __construct(
+        LoggerInterface $logger,
+        ContainerAwareEventManager $eventManager,
+        PaymentStatusUpdate $paymentStatusUpdate,
+        Configuration $configuration
+    ) {
+        $this->logger = $logger;
+        $this->eventManager = $eventManager;
+        $this->paymentStatusUpdate = $paymentStatusUpdate->setLogger($this->logger);
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * Returns boolean on whether this processor can process the Notification object
+     *
+     * @param Notification $notification
+     * @return boolean
+     */
+    public function supports(Notification $notification): bool
+    {
+        return strtoupper($notification->getEventCode()) === self::EVENT_CODE;
+    }
+
+    /**
+     * Actual processing of the notification
+     *
+     * @param Notification $notification
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     * @throws \Enlight_Event_Exception
+     */
+    public function process(Notification $notification)
+    {
+        $order = $notification->getOrder();
+
+        $this->eventManager->notify(
+            Event::NOTIFICATION_PROCESS_CANCELLATION,
+            [
+                'order' => $order,
+                'notification' => $notification
+            ]
+        );
+
+        if ($notification->isSuccess()) {
+            if ($this->configuration->getManualReviewRejectAction() == 'Cancel') {
+                $this->paymentStatusUpdate->updatePaymentStatus(
+                    $order,
+                    Status::PAYMENT_STATE_THE_PROCESS_HAS_BEEN_CANCELLED
+                );
+            }
+        }
+    }
+}

--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -72,6 +72,21 @@
           <label lang="en">Enable Payment Methods cache</label>
           <description lang="en">Caches the payment methods active in Adyen Customer Area for better performance.</description>
         </element>
+        <element required="true" type="select" scope="shop">
+            <name>manual_review_rejected_action</name>
+            <label lang="en">Manual Review Rejected Action</label>
+            <description lang="en">Select which action to perform on the order if a risk rule sends a payment to case management and is rejected. See https://docs.adyen.com/risk-management/case-management for more information.</description>
+            <store>
+                <option>
+                    <value>None</value>
+                    <label lang="en">None</label>
+                </option>
+                <option>
+                    <value>Cancel</value>
+                    <label lang="en">Cancel</label>
+                </option>
+            </store>
+        </element>
         <element type="button">
             <name>testAPIconnection</name>
             <label lang="en">Test API connection</label>

--- a/Resources/services/components.xml
+++ b/Resources/services/components.xml
@@ -170,6 +170,19 @@
             <argument type="service" id="events"/>
             <argument type="service" id="adyen_payment.components.payment_status_update"/>
         </service>
+        <service id="adyen_payment.components.notification_processor.manual_review_reject"
+                 class="AdyenPayment\Components\NotificationProcessor\ManualReviewReject">
+            <tag name="adyen.payment.notificationprocessor"/>
+            <argument type="service" id="adyen_payment.logger.notifications"/>
+            <argument type="service" id="events"/>
+            <argument type="service" id="adyen_payment.components.payment_status_update"/>
+            <argument type="service" id="adyen_payment.components.configuration"/>
+        </service>
+        <service id="adyen_payment.components.notification_processor.manual_review_accept"
+                 class="AdyenPayment\Components\NotificationProcessor\ManualReviewAccept">
+            <tag name="adyen.payment.notificationprocessor"/>
+            <argument type="service" id="events"/>
+        </service>
         <service id="adyen_payment.components.shopware_version_check" class="AdyenPayment\Components\ShopwareVersionCheck">
             <argument type="service" id="service_container" />
             <argument type="service" id="adyen_payment.logger"/>


### PR DESCRIPTION
## Summary
If a payment is sent to Adyen's Case Management and is rejected or accepted a webhook will be sent (if enabled for the risk profile).

MANUAL_REVIEW_ACCEPT won't perform any logic as the payment is being processed by the regular notification flow. MANUAL_REVIEW_REJECT will cancel the order if the config is set to Cancel. The config matches the documentation for Case Management modifications https://docs.adyen.com/risk-management/case-management#modifications

## Tested scenarios
* Config set to Cancel:
    * Process MANUAL_REVIEW_REJECT notification: cancels the order.
    * Process MANUAL_REVIEW_ACCEPT notification: N/A.

* Config set to None:
    * Process MANUAL_REVIEW_REJECT notification: N/A.
    * Process MANUAL_REVIEW_ACCEPT notification: N/A.

**Fixed issue**:  PW-4165
