### PR TITLE
PW-4139 Hide Adyen payment methods for 0 amount transactions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cyattilakiss @acampos1916 @msilvagarcia
+* @cyattilakiss @acampos1916 @msilvagarcia @peterojo

--- a/Components/PaymentMethodService.php
+++ b/Components/PaymentMethodService.php
@@ -216,6 +216,9 @@ class PaymentMethodService
         }
 
         $value = Shopware()->Session()->sOrderVariables['sBasket']['AmountNumeric'];
+        if (!$value) {
+            $value = Shopware()->Modules()->Basket()->sGetAmount()['totalAmount'];
+        }
 
         $paymentMethodOptions['countryCode'] = $countryCode;
         $paymentMethodOptions['currency'] = $currency;

--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -52,6 +52,8 @@
             var me = this;
             if (!$.isEmptyObject(me.opts.adyenSetSession)) {
                 me.sessionStorage.setItem(me.paymentMethodSession, JSON.stringify(me.opts.adyenSetSession));
+            } else {
+                me.sessionStorage.removeItem(me.paymentMethodSession);
             }
         },
 

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -127,8 +127,10 @@ class CheckoutSubscriber implements SubscriberInterface
      */
     public function checkoutFrontendPreDispatch(Enlight_Event_EventArgs $args)
     {
-        $this->rewritePostPayment($args);
-        $this->unsetPaymentSessions($args);
+        $subject = $args->getSubject();
+
+        $this->rewritePostPayment($subject);
+        $this->unsetPaymentSessions($subject);
     }
 
     /**
@@ -139,17 +141,17 @@ class CheckoutSubscriber implements SubscriberInterface
     {
         $subject = $args->getSubject();
 
-        $this->checkFirstCheckoutStep($args);
-        $this->rewritePaymentData($args);
-        $this->addAdyenConfigOnShipping($args);
-        $this->addAdyenGooglePay($args);
+        $this->checkFirstCheckoutStep($subject);
+        $this->rewritePaymentData($subject);
+        $this->addAdyenConfigOnShipping($subject);
+        $this->addAdyenGooglePay($subject);
 
         if (in_array($subject->Request()->getActionName(), ['shippingPayment', 'saveShippingPayment'])) {
-            $this->addPaymentSnippets($args);
+            $this->addPaymentSnippets($subject);
         }
 
         if (in_array($subject->Request()->getActionName(), ['confirm'])) {
-            $this->addConfirmSnippets($args);
+            $this->addConfirmSnippets($subject);
         }
     }
 
@@ -197,14 +199,11 @@ class CheckoutSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param Enlight_Event_EventArgs $args
+     * @param Shopware_Controllers_Frontend_Checkout $subject
      * @throws AdyenException
      */
-    private function addAdyenConfigOnShipping(Enlight_Event_EventArgs $args)
+    private function addAdyenConfigOnShipping(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         if (!in_array($subject->Request()->getActionName(), ['shippingPayment', 'confirm'])) {
             return;
         }
@@ -228,13 +227,10 @@ class CheckoutSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param Enlight_Event_EventArgs $args
+     * @param Shopware_Controllers_Frontend_Checkout $subject
      */
-    private function addConfirmSnippets(Enlight_Event_EventArgs $args)
+    private function addConfirmSnippets(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         $errorSnippets = $this->snippets->getNamespace('adyen/checkout/error');
 
         $snippets = [];
@@ -268,13 +264,10 @@ class CheckoutSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param Enlight_Event_EventArgs $args
+     * @param Shopware_Controllers_Frontend_Checkout $subject
      */
-    private function addPaymentSnippets(Enlight_Event_EventArgs $args)
+    private function addPaymentSnippets(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         $paymentSnippets = $this->snippets->getNamespace('adyen/checkout/payment');
 
         $snippets = [
@@ -299,13 +292,10 @@ class CheckoutSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param Enlight_Event_EventArgs $args
+     * @param Shopware_Controllers_Frontend_Checkout $subject
      */
-    private function rewritePaymentData(Enlight_Event_EventArgs $args)
+    private function rewritePaymentData(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         if (!in_array($subject->Request()->getActionName(), ['shippingPayment', 'saveShippingPayment'])) {
             return;
         }
@@ -322,13 +312,10 @@ class CheckoutSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param Enlight_Event_EventArgs $args
+     * @param Shopware_Controllers_Frontend_Checkout $subject
      */
-    private function rewritePostPayment(Enlight_Event_EventArgs $args)
+    private function rewritePostPayment(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         if (!in_array($subject->Request()->getActionName(), ['shippingPayment', 'saveShippingPayment'])) {
             return;
         }
@@ -354,11 +341,8 @@ class CheckoutSubscriber implements SubscriberInterface
         }
     }
 
-    private function addAdyenGooglePay(Enlight_Event_EventArgs $args)
+    private function addAdyenGooglePay(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         if (!in_array($subject->Request()->getActionName(), ['confirm'])) {
             return;
         }
@@ -397,11 +381,12 @@ class CheckoutSubscriber implements SubscriberInterface
         $subject->View()->assign('sAdyenGoogleConfig', htmlentities(json_encode($adyenGoogleConfig)));
     }
 
-    private function checkFirstCheckoutStep(Enlight_Event_EventArgs $args)
+    /**
+     * @param Shopware_Controllers_Frontend_Checkout $subject
+     * @throws AdyenException
+     */
+    private function checkFirstCheckoutStep(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         if (!in_array($subject->Request()->getActionName(), ['confirm'])) {
             return;
         }
@@ -462,11 +447,8 @@ class CheckoutSubscriber implements SubscriberInterface
         return !$this->session->offsetExists(AdyenPayment::SESSION_ADYEN_PAYMENT_VALID);
     }
 
-    private function unsetPaymentSessions(Enlight_Event_EventArgs $args)
+    private function unsetPaymentSessions(Shopware_Controllers_Frontend_Checkout $subject)
     {
-        /** @var Shopware_Controllers_Frontend_Checkout $subject */
-        $subject = $args->getSubject();
-
         if ($subject->Request()->getActionName() !== 'finish') {
             return;
         }

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -441,7 +441,7 @@ class CheckoutSubscriber implements SubscriberInterface
         $currency = Shopware()->Session()->sOrderVariables['sBasket']['sCurrencyName'];
         $value = Shopware()->Session()->sOrderVariables['sBasket']['AmountNumeric'];
 
-        if (empty((int) $value)) {
+        if (0 === (int)$value) {
             $this->revertToDefaultPaymentMethod($subject);
             return false;
         }

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -477,13 +477,11 @@ class CheckoutSubscriber implements SubscriberInterface
         $defaultPayment = Shopware()->Modules()->Admin()->sGetPaymentMeanById($defaultPaymentId);
         if (Shopware()->Modules()->Admin()->sUpdatePayment($defaultPaymentId)) {
             $this->adyenManager->unsetPaymentDataInSession();
+            // Replace Adyen payment method in the template with the default payment method.
             $userData = $subject->View()->getAssign('sUserData');
             $userData['additional']['payment'] = $defaultPayment;
-            unset($userData['additional']['user'][AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD]);
             $subject->View()->assign('sUserData', $userData);
             $subject->View()->clearAssign('sAdyenSetSession');
-
-            // @todo add message for user
         }
     }
 

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -432,13 +432,18 @@ class CheckoutSubscriber implements SubscriberInterface
         $currency = Shopware()->Session()->sOrderVariables['sBasket']['sCurrencyName'];
         $value = Shopware()->Session()->sOrderVariables['sBasket']['AmountNumeric'];
 
+        if (empty((int) $value)) {
+            // @todo remove payment info, don't redirect to shippingPayment
+            return false;
+        }
+
 
         $selectedType = $userData['additional']['user'][AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD];
-        
+
         if ($selectedType === null) {
             return true;
         }
-        
+
         $adyenPaymentMethods = PaymentMethodCollection::fromAdyenMethods(
             $this->paymentMethodService->getPaymentMethods($countryCode, $currency, $value)
         );

--- a/Subscriber/PaymentSubscriber.php
+++ b/Subscriber/PaymentSubscriber.php
@@ -99,6 +99,9 @@ class PaymentSubscriber implements SubscriberInterface
         });
 
         $paymentMethodOptions = $this->shopwarePaymentMethodService->getPaymentMethodOptions();
+        if ($paymentMethodOptions['value'] == 0) {
+            return $shopwareMethods;
+        }
         $adyenPaymentMethods = PaymentMethodCollection::fromAdyenMethods(
             $this->paymentMethodService->getPaymentMethods(
                 $paymentMethodOptions['countryCode'],


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->
## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
From issue #139 
This PR hides Adyen payment methods when the total amount in the basket is 0.
Resets the selected payment method to the shopware5 default when the amount has changed, e.g after applying a voucher.


## Tested scenarios
<!-- Description of tested scenarios -->
Pay for item that costs nothing
Apply voucher that sets total price to 0

**Fixed issue**:  #139  <!-- #-prefixed issue number -->
