### PR TITLE
Adding second notification where clause as andWhere

### DIFF
--- a/Components/NotificationManager.php
+++ b/Components/NotificationManager.php
@@ -49,7 +49,7 @@ class NotificationManager
     {
         $builder = $this->notificationRepository->createQueryBuilder('n');
         $builder->where("n.status = :statusReceived OR n.status = :statusRetry")
-            ->where('(n.scheduledProcessingTime <= :processingTime OR n.scheduledProcessingTime IS NULL)')
+            ->andWhere('(n.scheduledProcessingTime <= :processingTime OR n.scheduledProcessingTime IS NULL)')
             ->orderBy('n.updatedAt', 'ASC')
             ->setParameter('statusReceived', NotificationStatus::STATUS_RECEIVED)
             ->setParameter('statusRetry', NotificationStatus::STATUS_RETRY)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The first where clause to fetch the notifications to process was being replaced by the second one.

## Tested scenarios
Processing notifications uses all 3 bound parameters.


**Fixed issue**:  N/A
