### PR TITLE
[PW-4216] Showing all notifications in order details

### DIFF
--- a/Controllers/Backend/AdyenPaymentNotificationsListingExtension.php
+++ b/Controllers/Backend/AdyenPaymentNotificationsListingExtension.php
@@ -19,9 +19,7 @@ class Shopware_Controllers_Backend_AdyenPaymentNotificationsListingExtension ext
         $builder = parent::getListQuery();
 
         $builder->leftJoin('notification.order', 'nOrder')
-            ->addSelect(['nOrder'])
-            ->where("notification.status != :notificationStatus")
-            ->setParameter('notificationStatus', NotificationStatus::STATUS_HANDLED);
+            ->addSelect(['nOrder']);
 
         return $builder;
     }

--- a/Resources/views/backend/adyen_payment_order/view/detail/transaction_details.js
+++ b/Resources/views/backend/adyen_payment_order/view/detail/transaction_details.js
@@ -28,7 +28,7 @@ Ext.define('Shopware.apps.AdyenPaymentOrder.view.detail.TransactionDetails', {
         var me = this;
 
         me.detailsPanel = Ext.create('Ext.form.Panel', {
-            title: 'Transaction details',
+            title: 'Latest notification',
             titleAlign: 'left',
             bodyPadding: 10,
             layout: 'anchor',

--- a/Resources/views/backend/adyen_payment_order/view/detail/window.js
+++ b/Resources/views/backend/adyen_payment_order/view/detail/window.js
@@ -19,11 +19,7 @@ Ext.define('Shopware.apps.AdyenPaymentOrder.view.detail.Window', {
         var me = this,
             result = me.callParent();
 
-        if (!me.record.raw.adyenTransaction) {
-            return result;
-        }
-
-        result.add(me.createAdyenTab());
+        result.add(me.createAdyenTab(!!me.record.raw.adyenTransaction));
 
         return result;
     },
@@ -31,33 +27,35 @@ Ext.define('Shopware.apps.AdyenPaymentOrder.view.detail.Window', {
     /**
      * Generate Adyen Tab
      */
-    createAdyenTab: function () {
+    createAdyenTab: function (enableTab) {
         var me = this;
 
         var transactionStore = Ext.create('Shopware.apps.AdyenPaymentNotificationsListingExtension.store.Notification');
 
-        me.transactionDetails = Ext.create('Shopware.apps.AdyenPaymentOrder.view.detail.TransactionDetails', {
-            store: transactionStore,
-            layout: {
-                type: 'vbox',
-                align: 'stretch'
-            },
-            region: 'north'
-        });
-
-        me.transactionTabsDetail = Ext.create('Shopware.apps.AdyenPaymentOrder.view.detail.TransactionTabs', {
-            region: 'center',
-            store: transactionStore,
-            record: me.record
-        });
+        let items = [];
+        if (enableTab) {
+            items.push(
+                    Ext.create('Shopware.apps.AdyenPaymentOrder.view.detail.TransactionDetails', {
+                        store: transactionStore,
+                        layout: {
+                            type: 'vbox',
+                            align: 'stretch'
+                        },
+                        region: 'north'
+                    }),
+                    Ext.create('Shopware.apps.AdyenPaymentOrder.view.detail.TransactionTabs', {
+                        region: 'center',
+                        store: transactionStore,
+                        record: me.record
+                    })
+            );
+        }
 
         me.adyenTransactionTab = Ext.create('Ext.container.Container', {
-            title: 'Adyen Transactions',
+            title: 'Adyen Notifications',
             layout: 'border',
-            items: [
-                me.transactionDetails,
-                me.transactionTabsDetail
-            ]
+            items: items,
+            disabled: !enableTab
         });
 
         me.adyenTransactionTab.addListener('activate', function () {


### PR DESCRIPTION
## Summary
If an order has been processed with Adyen Payment Methods a new tab will show in the order details. Here it is being renamed to Adyen Notifications and now shows all notifications, not only the ones with status!=handled.

The tab now will always be shown for consistency, but disabled if no transaction is found (not an Adyen PM or no notification has been received).

## Tested scenarios
Orders show the tab regardless of PM, but enabled only for Adyen PM with notifications.
All notifications are shown regardless of status.


**Fixed issue**:  PW-4216
