### PR TITLE
AP-269 keep payment after shipping selection, add update info button

### DIFF
--- a/Resources/frontend/js/jquery.adyen-payment-selection.js
+++ b/Resources/frontend/js/jquery.adyen-payment-selection.js
@@ -120,13 +120,14 @@
             var me = this;
 
             // Return & clear when no adyen payment
-            if (me.currentSelectedPaymentType.indexOf(me.opts.adyenPaymentMethodPrefix) === -1) {
-                me.sessionStorage.removeItem(me.paymentMethodSession);
+            if (!me.__isAdyenPaymentMethod(me.currentSelectedPaymentType)) {
+                me.clearPaymentSession();
+
                 return;
             }
 
             var payment = me.getPaymentMethodByType(me.currentSelectedPaymentType);
-            if (me.__canHandlePayment(payment)) {
+            if (!me.__hasActivePaymentMethod()) {
                 $('#' + me.currentSelectedPaymentId)
                     .closest(me.opts.paymentMethodSelector)
                     .find(me.opts.methodBankdataSelector)
@@ -138,6 +139,7 @@
             }
 
             me.sessionStorage.setItem(me.paymentMethodSession, JSON.stringify(payment));
+            me.enableUpdatePaymentInfoButton();
         },
         setConfig: function () {
             var me = this;
@@ -242,7 +244,6 @@
 
             var form = $(me.opts.formSelector);
             var paymentMethod = form.find('input[name=payment]:checked');
-            var paymentMethodContainer = form.find('input[name=payment]:checked').closest(me.opts.paymentMethodSelector);
 
             if (!me.isPaymentMethodValid(paymentMethod)) {
                 return;
@@ -252,17 +253,12 @@
             me.currentSelectedPaymentType = paymentMethod.val();
 
             // Return when no data has been entered yet + see if component is needed
-            if (!me.sessionStorage.getItem(me.paymentMethodSession) ||
-                me.sessionStorage.getItem(me.paymentMethodSession) === "{}") {
+            if (!me.__hasActivePaymentMethod()) {
                 me.onPaymentChangedAfter();
                 return;
             }
 
-            me.changeInfosButton = $('<a/>')
-                .addClass(me.opts.classChangePaymentInfo)
-                .html(me.opts.adyenSnippets.updatePaymentInformation)
-                .on('click', $.proxy(me.updatePaymentInfo, me));
-            paymentMethodContainer.find(me.opts.methodBankdataSelector).append(me.changeInfosButton);
+            me.enableUpdatePaymentInfoButton();
         },
         isPaymentMethodValid: function (paymentMethod) {
             var me = this;
@@ -272,7 +268,7 @@
             }
 
             //Return when no adyen payment
-            if (paymentMethod.val().indexOf(me.opts.adyenPaymentMethodPrefix) === -1) {
+            if (!me.__isAdyenPaymentMethod(paymentMethod.val())) {
                 me.clearPaymentSession();
                 return false;
             }
@@ -331,6 +327,23 @@
 
             me.sessionStorage.setItem(me.adyenConfigSession, JSON.stringify(data));
         },
+        enableUpdatePaymentInfoButton: function() {
+            var me = this;
+            var paymentMethodContainer = $(me.opts.formSelector)
+                .find('input[name=payment]:checked')
+                .closest(me.opts.paymentMethodSelector);
+            if (!paymentMethodContainer) {
+                return;
+            }
+
+            me.changeInfosButton = $('<a/>')
+                .addClass(me.opts.classChangePaymentInfo)
+                .html(me.opts.adyenSnippets.updatePaymentInformation)
+                .on('click', $.proxy(me.updatePaymentInfo, me));
+            paymentMethodContainer
+                .find(me.opts.methodBankdataSelector)
+                .append(me.changeInfosButton);
+        },
         /**
          * @param {string} paymentType
          * @return {boolean}
@@ -359,6 +372,31 @@
         __isStoredPaymentMethod: function (paymentMethodId) {
             return !!this.getStoredPaymentMethodById(paymentMethodId);
         },
+        /**
+         * @return {boolean}
+         * @private
+         */
+        __hasActivePaymentMethod: function () {
+            var storedPaymentMethod =  this.sessionStorage.getItem(this.paymentMethodSession);
+            if (!storedPaymentMethod || "{}" === storedPaymentMethod) {
+                return false;
+            }
+
+            return true;
+        },
+        /**
+         * @param {string} paymentMethodType
+         * @return {boolean}
+         * @private
+         */
+        __isAdyenPaymentMethod: function (paymentMethodType) {
+            return paymentMethodType.indexOf(this.opts.adyenPaymentMethodPrefix) !== -1;
+        },
+        /**
+         * @param {object} paymentMethod
+         * @return {boolean}
+         * @private
+         */
         __canHandlePayment: function (paymentMethod) {
             if (this.__isStoredPaymentMethod(paymentMethod.id || '')) {
                 return true;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
* Update payment selection screen, verify  payment data selected stays stored in Session storage.
* When selecting a shipping method, validate if an active payment method is available.   
  if payment data is available do not reset the payment web component screen (show update info button)
* Show the "update info" button when active payment data is available, 
before it would  show an empty web component card for the payment option.

:no_entry: **Current Adyen development branch has a breaking change:**
:no_entry: updated development branch has an additional issue with me.opts.adyenIsAdyenPayment coming from BE.

```js
// file:  Resources/frontend/js/jquery.adyen-confirm-order.js

checkSetSession: function () {
     if (!$.isEmptyObject(me.opts.adyenSetSession)) {
//      ...  
      } else {
           me.sessionStorage.removeItem(me.paymentMethodSession);
     }
}
```
This `else` breaks the confirm page as it will clear the payment data from session storage which is needed for the actual payment process.


<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
* Select payment method Bancontact, continue to checkout confirm
* Select payment method Bancontact, change shipping method, continue to checkout confirm
* Select payment method Bancontact, re-select payment method MasterCard, continue to checkout confirm
* Select payment method Bancontact, change shipping method, re-select payment method MasterCard, continue to checkout 
* Select payment method Bancontact, change shipping method, re-select payment method MasterCard, change shipping method, continue to checkout confirm

**Fixed issue**:  #134 
