### PR TITLE
[PW-3963] Changing cancelAndRestoreByOrderNumber arg type to string

### DIFF
--- a/Components/BasketService.php
+++ b/Components/BasketService.php
@@ -78,14 +78,14 @@ class BasketService
     }
 
     /**
-     * @param int $orderNumber
+     * @param string $orderNumber
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
      * @throws \Enlight_Event_Exception
      * @throws \Enlight_Exception
      * @throws \Zend_Db_Adapter_Exception
      */
-    public function cancelAndRestoreByOrderNumber(int $orderNumber)
+    public function cancelAndRestoreByOrderNumber(string $orderNumber)
     {
         $order = $this->getOrderByOrderNumber($orderNumber);
         if (!$order) {
@@ -97,10 +97,10 @@ class BasketService
     }
 
     /**
-     * @param int $orderNumber
-     * @return Order|null
+     * @param string $orderNumber
+     * @return Order|null|object
      */
-    public function getOrderByOrderNumber(int $orderNumber)
+    public function getOrderByOrderNumber(string $orderNumber)
     {
         return $this->orderRepository->findOneBy(['number' => $orderNumber]);
     }

--- a/Components/OrderMailService.php
+++ b/Components/OrderMailService.php
@@ -25,9 +25,9 @@ class OrderMailService
 
     /**
      * Sends the mail after a payment is confirmed
-     * @param string|int $orderNumber
+     * @param string $orderNumber
      */
-    public function sendOrderConfirmationMail($orderNumber)
+    public function sendOrderConfirmationMail(string $orderNumber)
     {
         $order = $this->basketService->getOrderByOrderNumber($orderNumber);
         if (!$order) {

--- a/Subscriber/OrderEmailSubscriber.php
+++ b/Subscriber/OrderEmailSubscriber.php
@@ -114,7 +114,7 @@ class OrderEmailSubscriber implements SubscriberInterface
             return;
         }
 
-        $this->orderMailService->sendOrderConfirmationMail($data['sOrderNumber']);
+        $this->orderMailService->sendOrderConfirmationMail(strval($data['sOrderNumber']));
     }
 
     private function getOrderNumber($orderId)


### PR DESCRIPTION
## Summary
Changing cancelAndRestoreByOrderNumber arg type to string

## Tested scenarios
Redirect and non-redirect payments.

**Fixed issue**:  PW-3963
