### PR TITLE
Implement needed sUniqueID for Checkout finish page

### DIFF
--- a/Controllers/Frontend/Process.php
+++ b/Controllers/Frontend/Process.php
@@ -88,7 +88,8 @@ class Shopware_Controllers_Frontend_Process extends Shopware_Controllers_Fronten
                     $this->redirect([
                         'controller' => 'checkout',
                         'action' => 'finish',
-                        'sAGB' => true
+                        'sUniqueID' => $order->getTemporaryId(),
+                        'sAGB' => true,
                     ]);
                     break;
                 case PaymentResultCodes::CANCELLED:


### PR DESCRIPTION
## Summary
We use Shopware 5.6.8 and had a problem that after every order the user gets correctly redirected to the checkout confirm page but with the notice that the cart is empty. The order itself and the adyen transaction works fine but the user didn't get the correct confirm page displayed.

The problem is that the Shopware Frontend Checkout Controller requires the `sUniqueID` parameter which is in the order entity in the `Process` Controller of the adyen plugin implementation. I've just provided the parameter to the redirect and everything works as expected.

## Tested scenarios
Use showpare 5.6.8

**Fixed issue**:  <!-- #-prefixed issue number -->
