### PR TITLE
Update AuthenticationValidator.php to also support Apache CGI Mode Headers

### DIFF
--- a/Http/Validator/Notification/AuthenticationValidator.php
+++ b/Http/Validator/Notification/AuthenticationValidator.php
@@ -24,8 +24,8 @@ class AuthenticationValidator implements NotificationValidatorInterface
      */
     public function validate(array $notifications)
     {
-        $authUsername = $_SERVER['PHP_AUTH_USER'] ?? '';
-        $authPassword = $_SERVER['PHP_AUTH_PW'] ?? '';
+        $authUsername = $_SERVER['PHP_AUTH_USER'] ?? $_SERVER['HTTP_PHP_AUTH_USER'] ?? '';
+        $authPassword = $_SERVER['PHP_AUTH_PW'] ?? $_SERVER['HTTP_PHP_AUTH_PW'] ?? '';
 
         if (!$authUsername || !$authPassword) {
             throw InvalidAuthenticationException::missingAuthentication();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Our Apache2 in CGI Mode with PHP-FPM uses HTTP_PHP_AUTH_USER instead of PHP_AUTH_USER. We want this plugin to also check the header after checking PHP_AUTH_USER.

