### PR TITLE
[PW-4228] Making the notification's paymentMethod column nullable

### DIFF
--- a/Models/Notification.php
+++ b/Models/Notification.php
@@ -66,7 +66,7 @@ class Notification extends ModelEntity implements \JsonSerializable
 
     /**
      * @var string
-     * @ORM\Column(name="paymentMethod", type="text")
+     * @ORM\Column(name="paymentMethod", type="text", nullable=true)
      */
     private $paymentMethod;
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Some textNotifications might not have a paymentMethod object, and when these are converted into notifications a DB exception stops the whole queue. Here the paymentMethod column is being made nullable.

TODO A better flow and error handling can be implemented in the conversion to also avoid the bottlenecks for different kinds of exceptions.

## Tested scenarios
Processing CAPTURE notifications with no paymentMethod object doesn't stop the notification convert loop.

**Fixed issue**:  
PW-4228
Fixes #145 
