### PR TITLE
Restoring article order number to the basket after failed payment

### DIFF
--- a/Components/BasketService.php
+++ b/Components/BasketService.php
@@ -281,6 +281,7 @@ class BasketService
             'sessionID' => $this->session->get('sessionId'),
             'userID' => $this->session->get('sUserId') || 0,
             'articlename' => $optionData->getArticleName(),
+            'ordernumber' => $optionData->getArticleNumber(),
             'articleID' => $optionData->getArticleId(),
             'quantity' => $optionData->getQuantity(),
             'price' => $optionData->getPrice(),


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
After failed payments the basket line item's article number was not being restored. The column in Shopware's `s_order_basket` table is called `ordernumber`, but this holds the article number.

## Tested scenarios
One and multiple failed payments before a successful payment restores the basket line item with the article number

**Fixed issue**:  NA
