### PR TITLE
[PW-4602] Inserting payment method selection as user attribute if no user attribute exists

### DIFF
--- a/Components/PaymentMethodService.php
+++ b/Components/PaymentMethodService.php
@@ -120,17 +120,37 @@ class PaymentMethodService
     /**
      * @param int $userId
      * @param $payment
-     * @return bool
      */
     public function setUserAdyenMethod(int $userId, $payment)
     {
         $qb = $this->modelManager->getDBALQueryBuilder();
-        $qb->update('s_user_attributes', 'a')
-            ->set('a.' . AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD, ':payment')
-            ->where('a.userId = :customerId')
-            ->setParameter('payment', $payment)
+
+        $result = $qb->select(AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD)
+            ->from('s_user_attributes')
+            ->where('userId = :customerId')
             ->setParameter('customerId', $userId)
-            ->execute();
+            ->execute()
+            ->fetch();
+
+        if (empty($result)) {
+            $qb->insert('s_user_attributes')
+                ->values(
+                    array(
+                        AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD => ':payment',
+                        'userId' => ':customerId'
+                    )
+                )
+                ->setParameter('payment', $payment)
+                ->setParameter('customerId', $userId)
+                ->execute();
+        } else {
+            $qb->update('s_user_attributes', 'a')
+                ->set('a.' . AdyenPayment::ADYEN_PAYMENT_PAYMENT_METHOD, ':payment')
+                ->where('a.userId = :customerId')
+                ->setParameter('payment', $payment)
+                ->setParameter('customerId', $userId)
+                ->execute();
+        }
     }
 
     /**


### PR DESCRIPTION

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When the shopper has no rows in the `s_user_attributes` table the function responsible for updating the payment method selection fails. Here a check is introduced to either perform an insert or an update.

## Tested scenarios
Payment method selection with and without `s_user_attributes` for that user is successfully saved.


**Fixed issue**: PW-4602 fixes #41 
