### PR TITLE
[PW-4723] Make error_details column nullable for Shopware 5 notification

### DIFF
--- a/Models/Notification.php
+++ b/Models/Notification.php
@@ -102,7 +102,7 @@ class Notification extends ModelEntity implements \JsonSerializable
 
     /**
      * @var string
-     * @ORM\Column(name="error_details", type="text")
+     * @ORM\Column(name="error_details", type="text", nullable=true)
      */
     private $errorDetails;
 


### PR DESCRIPTION
## Summary
We can see the below log/issue if the errorDetails key is null in the notification (which can happen with PayPal):
```
array (
  'error' => 'An exception occurred while executing \'INSERT INTO s_plugin_adyen_order_notification (order_id, psp_reference, created_at, updated_at, status, paymentMethod, event_code, success, merchant_account_code, amount_value, amount_currency, error_details) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\' with params [171, "155xxxx075", "2021-05-21 13:45:01", "2021-05-21 13:45:01", "received", "paypal", "CAPTURE", 1, "XXX", 4417, "EUR", null]:
SQLSTATE[23000]: Integrity constraint violation: 1048 Column \'error_details\' cannot be null',
)
```