### PR TITLE
[PW-5047] Handle IdentifyShopper, ChallengeShopper, Pending and RedirectShopper with the same createFromAction

### DIFF
--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -100,7 +100,7 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
 
     /**
      * @throws AdyenException
-     * @depracted will be removed in 3.0.0 to move closer to a generic implementation,
+     * @deprecated will be removed in 3.0.0 to move closer to a generic implementation,
      * use paymentDetailsAction() instead
      */
     public function ajaxThreeDsAction()

--- a/Controllers/Frontend/Adyen.php
+++ b/Controllers/Frontend/Adyen.php
@@ -100,6 +100,8 @@ class Shopware_Controllers_Frontend_Adyen extends Shopware_Controllers_Frontend_
 
     /**
      * @throws AdyenException
+     * @depracted will be removed in 3.0.0 to move closer to a generic implementation,
+     * use paymentDetailsAction() instead
      */
     public function ajaxThreeDsAction()
     {

--- a/Resources/frontend/js/jquery.adyen-confirm-order.js
+++ b/Resources/frontend/js/jquery.adyen-confirm-order.js
@@ -14,7 +14,7 @@
             adyenSetSession: {},
             adyenIsAdyenPayment: false,
             adyenAjaxDoPaymentUrl: '/frontend/adyen/ajaxDoPayment',
-            adyenAjaxThreeDsUrl: '/frontend/adyen/ajaxThreeDs',
+            adyenAjaxPaymentDetails: '/frontend/adyen/paymentDetails',
             adyenSnippets: {
                 errorTransactionCancelled: 'Your transaction was cancelled by the Payment Service Provider.',
                 errorTransactionProcessing: 'An error occured while processing your payment.',
@@ -120,11 +120,9 @@
                     break;
                 case 'IdentifyShopper':
                 case 'ChallengeShopper':
-                    me.handleThreeDs(data);
-                    break;
                 case 'Pending':
                 case 'RedirectShopper':
-                    me.handlePaymentDataRedirectShopper(data);
+                    me.handlePaymentDataCreateFromAction(data);
                     break;
                 default:
                     me.handlePaymentDataError(data);
@@ -137,17 +135,17 @@
             $(me.opts.confirmFormSelector).submit();
         },
 
-        handleThreeDs: function (data) {
+        handlePaymentDataCreateFromAction: function (data) {
             var me = this;
-            var threeDsAction = {
+            var payload = {
                 resultCode: data.resultCode,
                 type: data.action.type,
                 subtype: data.action.subtype
             };
-            var modal = $.modal.open('<div id="AdyenThreeDS2"/>', {
+            var modal = $.modal.open('<div id="AdyenModal"/>', {
                 showCloseButton: false,
                 closeOnOverlay: false,
-                additionalClass: 'adyen-challenge-shopper'
+                additionalClass: 'adyen-modal'
             });
 
             me.adyenCheckout
@@ -157,9 +155,9 @@
                         $.ajax({
                             method: 'POST',
                             dataType: 'json',
-                            url: me.opts.adyenAjaxThreeDsUrl,
+                            url: me.opts.adyenAjaxPaymentDetails,
                             data: {
-                                'action': threeDsAction,
+                                'action': payload,
                                 'details': state.data.details,
                             },
                             success: function (response) {
@@ -171,7 +169,7 @@
                         console.error(error);
                     }
                 })
-                .mount('#AdyenThreeDS2');
+                .mount('#AdyenModal');
         },
 
         handlePaymentDataRedirectShopper: function (data) {

--- a/Resources/frontend/less/all.less
+++ b/Resources/frontend/less/all.less
@@ -24,7 +24,7 @@
   }
 }
 
-.adyen-challenge-shopper .content {
+.adyen-modal .content {
   padding: 20px;
 }
 


### PR DESCRIPTION


<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Payment methods that returned Pending and a QR code action (like bcmc_mobile/Payconiq) successfully created the component but were not mounting it so that the code could be shown. Here these result codes are being combined with the handling of IdentifyShopper, ChallengeShopper. The component will take care of the appropriate action.

## Tested scenarios
Happy and unhappy flows for bcmc_mobile/Payconiq, 3DS1, 3DS2, iDeal.


**Fixed issue**:  PW-5047
