### PR TITLE
Fix GooglePay

### DIFF
--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -381,7 +381,7 @@ class CheckoutSubscriber implements SubscriberInterface
                 'merchantName' => Shopware()->Shop()->getName()
             ],
         ];
-        if ($this->configuration->getEnvironment() === Configuration::ENV_LIVE) {
+        if ($this->configuration->getEnvironment() === strtolower(Configuration::ENV_LIVE)) {
             $adyenGoogleConfig['environment'] = 'PRODUCTION';
             $adyenGoogleConfig['configuration']['merchantIdentifier'] = $this->configuration->getGoogleMerchantId();
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We had Problems getting Google Pay to work. We debugged the code and saw that the Environment-Check is wrong. 
`$this->configuration->getEnvironment()` (see below) will **always** return a lowercased value, because of the constants refering to https://github.com/Adyen/adyen-php-api-library/blob/develop/src/Adyen/Environment.php are lowercased
```
    /**
     * @param bool $shop
     * @return string
     */
    public function getEnvironment($shop = false, $lowercase = false): string
    {
        $environment = Environment::TEST;
        if ($this->getConfig('environment', $shop) === self::ENV_LIVE) {
            $environment = Environment::LIVE;
        }

        if ($lowercase) {
            return strtolower($environment);
        }

        return $environment;
    }
```

## Tested scenarios
Tested on production Environment, checking the data-adyenGoogleConfig will show PRODUCTION Environment including the merchantIdentifier instead of showing the TESTING Environment without this fix

You can test it on a checkout page by adding the following code before my change and add ?foo to the url:
```
        if ($subject->Request()->query->has('foo')) {
            var_dump($this->configuration->getEnvironment());
            var_dump(Configuration::ENV_LIVE);
            var_dump($this->configuration->getEnvironment() === Configuration::ENV_LIVE);
            die();
        }
```
It will print out:
```
string(4) "live" string(4) "LIVE" bool(false)
```
**Fixed issue**:  Don't have one, but our E-Mail request was #2162142
