### PR TITLE
Fix env constants

### DIFF
--- a/Components/Configuration.php
+++ b/Components/Configuration.php
@@ -17,8 +17,8 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  */
 class Configuration
 {
-    const ENV_TEST = 'TEST';
-    const ENV_LIVE = 'LIVE';
+    const ENV_TEST = 'test';
+    const ENV_LIVE = 'live';
     const PAYMENT_PREFIX = 'adyen_';
     const PAYMENT_LENGHT = 6;
 
@@ -46,13 +46,11 @@ class Configuration
     /**
      * @param Shop|bool $shop
      */
-    public function getEnvironment($shop = false, $lowercase = false): string
+    public function getEnvironment($shop = false): string
     {
-        $environment = self::ENV_LIVE === $this->getConfig('environment', $shop)
+        return self::ENV_LIVE === strtolower($this->getConfig('environment', $shop))
             ? Environment::LIVE
             : Environment::TEST;
-
-        return  (true === $lowercase) ? strtolower($environment) : $environment;
     }
 
     /**
@@ -109,7 +107,7 @@ class Configuration
     public function getApiKey($shop = false): string
     {
         return (string)$this->getConfig(
-            'api_key_' . $this->getEnvironment($shop, true),
+            'api_key_' . $this->getEnvironment($shop),
             $shop
         );
     }
@@ -125,7 +123,7 @@ class Configuration
 
     public function getClientKey(Shop $shop): string
     {
-        return (string)$this->getConfig('client_key_'.$this->getEnvironment($shop, true), $shop);
+        return (string)$this->getConfig('client_key_'.$this->getEnvironment($shop), $shop);
     }
 
     /**
@@ -135,7 +133,7 @@ class Configuration
     public function getNotificationHmac($shop = false): string
     {
         return (string)$this->getConfig(
-            'notification_hmac_' . $this->getEnvironment($shop, true),
+            'notification_hmac_' . $this->getEnvironment($shop),
             $shop
         );
     }
@@ -147,7 +145,7 @@ class Configuration
     public function getNotificationAuthUsername($shop = false): string
     {
         return (string)$this->getConfig(
-            'notification_auth_username_' . $this->getEnvironment($shop, true),
+            'notification_auth_username_' . $this->getEnvironment($shop),
             $shop
         );
     }
@@ -159,7 +157,7 @@ class Configuration
     public function getNotificationAuthPassword($shop = false): string
     {
         return (string)$this->getConfig(
-            'notification_auth_password_' . $this->getEnvironment($shop, true),
+            'notification_auth_password_' . $this->getEnvironment($shop),
             $shop
         );
     }

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -381,7 +381,7 @@ class CheckoutSubscriber implements SubscriberInterface
                 'merchantName' => Shopware()->Shop()->getName()
             ],
         ];
-        if ($this->configuration->getEnvironment() === strtolower(Configuration::ENV_LIVE)) {
+        if ($this->configuration->getEnvironment() === Configuration::ENV_LIVE) {
             $adyenGoogleConfig['environment'] = 'PRODUCTION';
             $adyenGoogleConfig['configuration']['merchantIdentifier'] = $this->configuration->getGoogleMerchantId();
         }

--- a/Subscriber/CheckoutSubscriber.php
+++ b/Subscriber/CheckoutSubscriber.php
@@ -381,7 +381,7 @@ class CheckoutSubscriber implements SubscriberInterface
                 'merchantName' => Shopware()->Shop()->getName()
             ],
         ];
-        if ($this->configuration->getEnvironment() === Configuration::ENV_LIVE) {
+        if ($this->configuration->getEnvironment() === strtolower(Configuration::ENV_LIVE)) {
             $adyenGoogleConfig['environment'] = 'PRODUCTION';
             $adyenGoogleConfig['configuration']['merchantIdentifier'] = $this->configuration->getGoogleMerchantId();
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`\AdyenPayment\Components\Configuration::getEnvironment` was always returning lowercase environment anyway since it returns the constants from `\Adyen\Environment`.
This PR uses lowercase constants for environment variables in `\AdyenPayment\Components\Configuration` to align with the php lib and also fix the issue reported in #179. 

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**: #179  <!-- #-prefixed issue number -->
